### PR TITLE
Upgrade Renovate config to best-practices preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices",
+    "schedule:weekly"
+  ],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group Astro ecosystem packages",
+      "matchPackageNames": ["astro"],
+      "matchPackagePatterns": ["^@astrojs/", "^astro-"],
+      "groupName": "astro ecosystem"
+    },
+    {
+      "description": "Group styling/CSS packages",
+      "matchPackageNames": ["tailwindcss", "postcss", "autoprefixer", "sass"],
+      "groupName": "styling dependencies"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Upgrade from `config:recommended` to `config:best-practices` preset, which adds weekly lock file maintenance, npm 3-day unpublish safety, GitHub Actions SHA pinning, and automated config migration
- Add `schedule:weekly` to batch updates on weekends and reduce notification noise
- Add `dependencies` label for easy PR filtering
- Group Astro ecosystem packages (`astro`, `@astrojs/*`, `astro-*`) and styling packages (`tailwindcss`, `postcss`, `autoprefixer`, `sass`) to reduce PR count

## Best Practices Gap Analysis

| # | Best Practice | Benefit | Status |
|---|---|---|---|
| 1 | `config:best-practices` preset | HIGH | ✅ Added |
| 2 | Lock file maintenance (weekly) | HIGH | ✅ Included via preset |
| 3 | Weekly schedule | MEDIUM | ✅ Added |
| 4 | Group related dependencies | MEDIUM | ✅ Added |
| 5 | Minimum release age (npm safety) | MEDIUM | ✅ Included via preset |
| 6 | Pin GitHub Actions by SHA | MEDIUM | ✅ Included via preset |
| 7 | PR labels | LOW-MEDIUM | ✅ Added |

Sources:
- [Renovate Upgrade Best Practices](https://docs.renovatebot.com/upgrade-best-practices/)
- [Renovate Full Config Presets](https://docs.renovatebot.com/presets-config/)
- [Renovate Noise Reduction](https://docs.renovatebot.com/noise-reduction/)

## Test plan
- [x] Config validated with `renovate-config-validator` ✅
- [ ] Verify Renovate processes the new config on next run
- [ ] Confirm GitHub Actions get pinned by SHA in follow-up PRs
- [ ] Confirm lock file maintenance PR appears weekly

🤖 Generated with [Claude Code](https://claude.com/claude-code)