### PR TITLE
ci: add paths-ignore to astro-build workflow

### DIFF
--- a/.github/workflows/astro-build.yml
+++ b/.github/workflows/astro-build.yml
@@ -4,7 +4,19 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.github/**'
+      - 'README.md'
+      - 'LICENSE'
+      - 'renovate.json'
+      - '.claude/**'
   pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'README.md'
+      - 'LICENSE'
+      - 'renovate.json'
+      - '.claude/**'
   schedule:
     - cron: "5 1 * * *" # Run nightly
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to `push` and `pull_request` triggers in the Astro build workflow
- Skips unnecessary builds when only non-build files change (`.github/**`, `README.md`, `LICENSE`, `renovate.json`, `.claude/**`)
- Nightly schedule and manual dispatch remain unfiltered as safety nets

## Test plan
- [ ] Verify workflow still triggers on PRs that modify source/config files
- [ ] Verify workflow is skipped for PRs that only touch ignored paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)