### PR TITLE
ci: use node-version-file in links workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v6.3.0
         with:
-          node-version: 24.14.0
+          node-version-file: ".node-version"
 
       - name: Run make clean
         run: make clean


### PR DESCRIPTION
## Summary
- Replace hardcoded `node-version: 24.14.0` with `node-version-file: ".node-version"` in the links workflow
- Matches the approach already used in `astro-build.yml`
- Both workflows now automatically pick up Node.js version updates from a single source

## Test plan
- [ ] Verify the links workflow still runs successfully with the `.node-version` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)