### PR TITLE
chore: remove unused @astrojs/markdown-component dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "@andygrunwald/homepage",
       "version": "1.0.0",
       "dependencies": {
-        "@astrojs/markdown-component": "^1.0.5",
         "@astrojs/mdx": "^4.3.13",
         "@astrojs/rss": "^4.0.14",
         "@astrojs/sitemap": "^3.6.0",
@@ -44,12 +43,6 @@
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
       "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
-      "license": "MIT"
-    },
-    "node_modules/@astrojs/markdown-component": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-component/-/markdown-component-1.0.5.tgz",
-      "integrity": "sha512-e7pzVfEZmjyZMmKGwLbfds36idAt9Yi8c0N0VQw2cVEgK8QdQecZLc07JvUSugoZxINtoVA0Afpm8EcIP52Ncw==",
       "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,12 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/markdown-component": "^1.0.5",
     "@astrojs/mdx": "^4.3.13",
     "@astrojs/rss": "^4.0.14",
     "@astrojs/sitemap": "^3.6.0",
     "@astrojs/tailwind": "^6.0.0",
-    "astro-remote": "^0.3.4",
     "astro": "^5.16.6",
+    "astro-remote": "^0.3.4",
     "autoprefixer": "^10.4.23",
     "netlify-purge-cloudflare-on-deploy": "^1.2.0",
     "postcss": "^8.5.6",


### PR DESCRIPTION
## Summary
- Remove `@astrojs/markdown-component` from dependencies — it is deprecated by Astro and not imported anywhere in the codebase
- Reduces install time and avoids potential future conflicts

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify site renders correctly (homepage, blog posts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)