### PR TITLE
fix: validate YouTube video ID before embedding

### DIFF
--- a/src/components/YouTube.astro
+++ b/src/components/YouTube.astro
@@ -5,6 +5,10 @@ export interface Props {
 }
 
 const { id, description } = Astro.props;
+
+if (!/^[a-zA-Z0-9_-]{11}$/.test(id)) {
+	throw new Error(`Invalid YouTube video ID: "${id}". Expected 11 characters of [a-zA-Z0-9_-].`);
+}
 ---
 <div class="text-center">
 	<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">


### PR DESCRIPTION
## Summary
- Add regex validation (`/^[a-zA-Z0-9_-]{11}$/`) to the YouTube component's `id` prop
- Throws a build-time error if the ID doesn't match the expected YouTube format
- Prevents malformed IDs from producing unexpected iframe URLs

## Test plan
- [x] `npm run build` succeeds with existing YouTube embeds
- [ ] Verify YouTube embeds still render correctly on blog posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)