### PR TITLE
fix: add meaningful alt text to blog post images

### DIFF
--- a/src/components/BlogPostPreviewWithImage.astro
+++ b/src/components/BlogPostPreviewWithImage.astro
@@ -51,7 +51,7 @@ if (post.data.images.length > 0) {
 	{hasImage && <div class="order-first lg:order-last w-full lg:w-3/5 px-4 mb-8 lg:mb-0">
 		<div class="h-96">
 			<a href={`/blog/${post.slug}/`} title={post.data.title}>
-				<img class="w-full h-full object-cover rounded-lg" src={imagePath} alt="">
+				<img class="w-full h-full object-cover rounded-lg" src={imagePath} alt={post.data.title}>
 			</a>
 		</div>
 	</div>}
@@ -63,7 +63,7 @@ if (post.data.images.length > 0) {
 	{hasImage && <div class="w-full lg:w-3/5 px-4 mb-8 lg:mb-0">
 		<div class="h-96">
 			<a href={`/blog/${post.slug}/`} title={post.data.title}>
-				<img class="w-full h-full object-cover rounded-lg" src={imagePath} alt="">
+				<img class="w-full h-full object-cover rounded-lg" src={imagePath} alt={post.data.title}>
 			</a>
 		</div>
 	</div>}

--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -60,7 +60,7 @@ if (content.images.length > 0) {
 			      </div>
           </div>
 		      {hasImage && <div class="h-112 mb-10">
-            <img class="w-full h-full object-cover object-top rounded-lg" src={imagePath} alt="">
+            <img class="w-full h-full object-cover object-top rounded-lg" src={imagePath} alt={content.title}>
           </div>}
 
 		      <div class="max-w-2xl mx-auto">


### PR DESCRIPTION
## Summary
- Replace empty `alt=""` with `alt={content.title}` / `alt={post.data.title}` on blog post header images
- Affects `blog-post.astro` layout and `BlogPostPreviewWithImage.astro` component
- Improves accessibility for screen reader users

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify images render with proper alt text in browser dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)