### PR TITLE
refactor: extract shared blog post sorting into utility

### DIFF
--- a/src/components/BlogPostPreviewListing.astro
+++ b/src/components/BlogPostPreviewListing.astro
@@ -1,6 +1,6 @@
 ---
-import { getCollection } from "astro:content";
 import BlogPostPreview from '../components/BlogPostPreview.astro';
+import { getSortedBlogPosts } from "../scripts/blog.js";
 
 export interface Props {
 	// Number of items to show in the listing
@@ -9,11 +9,7 @@ export interface Props {
 
 const { numberOfItems } = Astro.props;
 
-// Build the list of posts
-// Fetch all posts, and then sort them by date.
-const allPosts = (await getCollection("blog")).sort(
-	(a, b) => new Date(b.data.pubDate).valueOf() - new Date(a.data.pubDate).valueOf()
-);
+const allPosts = await getSortedBlogPosts();
 
 // Default wise list all items, only limit it if requested
 let postsToShow = allPosts;

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,10 +1,8 @@
 import rss from '@astrojs/rss';
-import { getCollection } from 'astro:content';
+import { getSortedBlogPosts } from "../scripts/blog.js";
 
 export async function GET(context) {
-    const blogPosts = (await getCollection("blog")).sort(
-        (a, b) => new Date(b.data.pubDate).valueOf() - new Date(a.data.pubDate).valueOf()
-    );
+    const blogPosts = await getSortedBlogPosts();
     return rss({
         title: 'Andy Grunwald (andygrunwald.com)',
         description: 'Software Engineer and Engineering Manager. Open Source enthusiast with a passion for Backend, Infrastructure, Reliability and Engineering Culture.',

--- a/src/scripts/blog.js
+++ b/src/scripts/blog.js
@@ -1,0 +1,7 @@
+import { getCollection } from "astro:content";
+
+export async function getSortedBlogPosts() {
+	return (await getCollection("blog")).sort(
+		(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+	);
+}


### PR DESCRIPTION
## Summary
- Extract duplicated blog post fetch-and-sort logic into `getSortedBlogPosts()` in `src/scripts/blog.js`
- Remove redundant `new Date()` wrapping (Zod schema already validates `pubDate` as a Date)
- Update `BlogPostPreviewListing.astro` and `rss.xml.js` to use the shared utility

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify blog listing page shows posts in correct date order
- [ ] Verify RSS feed still generates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)