### PR TITLE
refactor: extract CategoryBadge component to eliminate duplication

### DIFF
--- a/src/components/BlogPostPreview.astro
+++ b/src/components/BlogPostPreview.astro
@@ -5,6 +5,7 @@ export interface Props {
 }
 
 import { Markdown } from 'astro-remote';
+import CategoryBadge from './CategoryBadge.astro';
 import { formatDate } from "../scripts/date.js"
 
 const { post, n } = Astro.props;
@@ -14,10 +15,7 @@ const { post, n } = Astro.props;
 <div class="flex flex-wrap items-center -mx-4 mb-20">
 	<div class="w-full px-4">
 		<div class="text-left">
-			{post.data.categories.map((category) => <span class="inline-block mb-3 mr-2 text-xs px-2 py-1 bg-blue-50 rounded uppercase text-blue-400 font-semibold">
-					{category}
-				</span>
-			)}
+			{post.data.categories.map((category) => <CategoryBadge category={category} />)}
 			<h2 class="mb-4 text-3xl font-semibold font-heading">
 				<a href={`/blog/${post.slug}/`} title={post.data.title} class="hover:underline hover:text-red-300">
 					{post.data.title}

--- a/src/components/BlogPostPreviewWithImage.astro
+++ b/src/components/BlogPostPreviewWithImage.astro
@@ -12,6 +12,7 @@ export interface Props {
 }
 
 import { Markdown } from 'astro-remote';
+import CategoryBadge from './CategoryBadge.astro';
 import { formatDate } from "../scripts/date.js"
 
 const { post, n } = Astro.props;
@@ -33,10 +34,7 @@ if (post.data.images.length > 0) {
 <div class="flex flex-wrap items-center -mx-4 mb-16">
 	<div class={"w-full px-4 " + imageWidthClass}>
 		<div class="text-left">
-			{post.data.categories.map((category) => <span class="inline-block mb-3 mr-2 text-xs px-2 py-1 bg-blue-50 rounded uppercase text-blue-400 font-semibold">
-					{category}
-				</span>
-			)}
+			{post.data.categories.map((category) => <CategoryBadge category={category} />)}
 			<h2 class="mb-4 text-3xl font-semibold font-heading">
 				<a href={`/blog/${post.slug}/`} title={post.data.title} class="hover:underline hover:text-red-300">
 					{post.data.title}
@@ -69,10 +67,7 @@ if (post.data.images.length > 0) {
 	</div>}
 	<div class={"w-full px-4 " + imageWidthClass}>
 		<div class={"text-left" + imagePaddingLeftClass}>
-			{post.data.categories.map((category) => <span class="inline-block mb-3 mr-2 text-xs px-2 py-1 bg-blue-50 rounded uppercase text-blue-400 font-semibold">
-					{category}
-				</span>
-			)}
+			{post.data.categories.map((category) => <CategoryBadge category={category} />)}
 			<h2 class="mb-4 text-3xl font-semibold font-heading">
 				<a href={`/blog/${post.slug}/`} title={post.data.title} class="hover:underline hover:text-red-300">
 					{post.data.title}

--- a/src/components/CategoryBadge.astro
+++ b/src/components/CategoryBadge.astro
@@ -1,0 +1,10 @@
+---
+export interface Props {
+	category: string;
+}
+
+const { category } = Astro.props;
+---
+<span class="inline-block mb-3 mr-2 text-xs px-2 py-1 bg-blue-50 rounded uppercase text-blue-400 font-semibold">
+	{category}
+</span>

--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -2,6 +2,7 @@
 import MainHead from '../components/MainHead.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+import CategoryBadge from '../components/CategoryBadge.astro';
 import { formatDate } from "../scripts/date.js"
 
 import '../styles/blogpost.scss';
@@ -53,9 +54,7 @@ if (content.images.length > 0) {
 					      </p>
 				      </div>
 				      <div class="text-center">
-					      {content.categories.map((category) => <span class="inline-block mb-3 mx-2 text-xs px-2 py-1 bg-blue-50 rounded uppercase text-blue-400 font-semibold">
-						      {category}
-					      </span>)}
+					      {content.categories.map((category) => <CategoryBadge category={category} />)}
 				      </div>
 			      </div>
           </div>


### PR DESCRIPTION
## Summary
- Create new `CategoryBadge.astro` component for the category badge pattern
- Replace 4 duplicated instances across `BlogPostPreview.astro`, `BlogPostPreviewWithImage.astro`, and `blog-post.astro`
- Single source of truth for category badge styling

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify category badges render correctly on blog listing and individual posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)