### PR TITLE
fix: replace post: any with proper CollectionEntry type

### DIFF
--- a/src/components/BlogPostPreview.astro
+++ b/src/components/BlogPostPreview.astro
@@ -1,10 +1,11 @@
 ---
+import type { CollectionEntry } from 'astro:content';
+import { Markdown } from 'astro-remote';
+
 export interface Props {
-	post: any;
+	post: CollectionEntry<'blog'>;
 	n: number;
 }
-
-import { Markdown } from 'astro-remote';
 import CategoryBadge from './CategoryBadge.astro';
 import { formatDate } from "../scripts/date.js"
 

--- a/src/components/BlogPostPreviewWithImage.astro
+++ b/src/components/BlogPostPreviewWithImage.astro
@@ -6,12 +6,13 @@
 // However, they didn't look great: Wrong / too strong colours, wrong sizing, etc.
 //
 // At some point in time, we want to use this component.
+import type { CollectionEntry } from 'astro:content';
+import { Markdown } from 'astro-remote';
+
 export interface Props {
-	post: any;
+	post: CollectionEntry<'blog'>;
 	n: number;
 }
-
-import { Markdown } from 'astro-remote';
 import CategoryBadge from './CategoryBadge.astro';
 import { formatDate } from "../scripts/date.js"
 


### PR DESCRIPTION
## Summary
- Replace `post: any` with `post: CollectionEntry<'blog'>` in `BlogPostPreview.astro` and `BlogPostPreviewWithImage.astro`
- Enables TypeScript to catch type errors at build time instead of runtime

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify blog listing renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)