### PR TITLE
refactor: modernize main.js burger menu code

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,40 +1,17 @@
-// Burger menus
 document.addEventListener('DOMContentLoaded', function() {
-    // open
-    const burger = document.querySelectorAll('.navbar-burger');
     const menu = document.querySelectorAll('.navbar-menu');
 
-    if (burger.length && menu.length) {
-        for (var i = 0; i < burger.length; i++) {
-            burger[i].addEventListener('click', function() {
-                for (var j = 0; j < menu.length; j++) {
-                    menu[j].classList.toggle('hidden');
-                }
-            });
-        }
+    function toggleMenu() {
+        menu.forEach(function(el) { el.classList.toggle('hidden'); });
     }
 
-    // close
-    const close = document.querySelectorAll('.navbar-close');
-    const backdrop = document.querySelectorAll('.navbar-backdrop');
-
-    if (close.length) {
-        for (var i = 0; i < close.length; i++) {
-            close[i].addEventListener('click', function() {
-                for (var j = 0; j < menu.length; j++) {
-                    menu[j].classList.toggle('hidden');
-                }
-            });
-        }
-    }
-
-    if (backdrop.length) {
-        for (var i = 0; i < backdrop.length; i++) {
-            backdrop[i].addEventListener('click', function() {
-                for (var j = 0; j < menu.length; j++) {
-                    menu[j].classList.toggle('hidden');
-                }
-            });
-        }
-    }
+    document.querySelectorAll('.navbar-burger').forEach(function(el) {
+        el.addEventListener('click', toggleMenu);
+    });
+    document.querySelectorAll('.navbar-close').forEach(function(el) {
+        el.addEventListener('click', toggleMenu);
+    });
+    document.querySelectorAll('.navbar-backdrop').forEach(function(el) {
+        el.addEventListener('click', toggleMenu);
+    });
 });


### PR DESCRIPTION
## Summary
- Replace `var` with `const`, C-style `for` loops with `forEach`
- Extract 3 identical toggle-hidden handlers into a shared `toggleMenu` function
- Reduces 40 lines to 17 with identical behavior

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify mobile hamburger menu opens and closes correctly
- [ ] Verify backdrop click closes the menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)