### PR TITLE
fix: add defensive validation to formatDate utility

### DIFF
--- a/src/scripts/date.js
+++ b/src/scripts/date.js
@@ -1,9 +1,13 @@
+const options = {
+	weekday: 'long',
+	year: 'numeric',
+	month: 'long',
+	day: 'numeric'
+};
+
 export function formatDate(date) {
-	const options = {
-		weekday: 'long',
-		year: 'numeric',
-		month: 'long',
-		day: 'numeric'
-	};
-	return new Date(date).toLocaleDateString('en-GB', options);
+	if (!date) return '';
+	const d = new Date(date);
+	if (isNaN(d.getTime())) return '';
+	return d.toLocaleDateString('en-GB', options);
 }


### PR DESCRIPTION
## Summary
- Add null/undefined guard to `formatDate()` — returns empty string instead of "Invalid Date"
- Add `isNaN` check for invalid date values
- Move `options` constant outside the function to avoid re-creation on each call

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify dates still display correctly on blog posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)