### PR TITLE
refactor: use template literal instead of string concat for title

### DIFF
--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -10,7 +10,7 @@ const { blogPost } = Astro.props;
 const content = blogPost.data;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-let title = "".concat(content.title, " - Andy Grunwald");
+let title = `${content.title} - Andy Grunwald`;
 
 let hasImage = false;
 let imagePath = "";


### PR DESCRIPTION
## Summary
- Replace `"".concat(content.title, " - Andy Grunwald")` with `` `${content.title} - Andy Grunwald` ``
- Improves readability with no behavior change

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify blog post page titles render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)