### PR TITLE
Add JSON-LD structured data

### DIFF
--- a/src/components/JsonLd.astro
+++ b/src/components/JsonLd.astro
@@ -1,0 +1,12 @@
+---
+export interface Props {
+  schema: Record<string, unknown>;
+}
+
+const { schema } = Astro.props;
+
+// Escape `<` so the serialized JSON can never terminate the <script> element early.
+const json = JSON.stringify(schema).replace(/</g, "\\u003c");
+---
+
+<script type="application/ld+json" set:html={json} />

--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -4,6 +4,7 @@ import MainHead from "../components/MainHead.astro";
 import Nav from "../components/Nav.astro";
 import Footer from "../components/Footer.astro";
 import CategoryBadge from "../components/CategoryBadge.astro";
+import JsonLd from "../components/JsonLd.astro";
 import { formatDate } from "../scripts/date.js";
 import { resolvePostImage } from "../scripts/post-images.js";
 
@@ -38,6 +39,23 @@ if (resolvedImage) {
 } else if (firstImage) {
   metaTagImage = firstImage;
 }
+
+const blogPostingSchema = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  headline: content.title,
+  description: content.description,
+  datePublished: content.pubDate.toISOString(),
+  dateModified: content.lastmod.toISOString(),
+  keywords: content.keywords,
+  image: new URL(metaTagImage, Astro.site).href,
+  mainEntityOfPage: { "@type": "WebPage", "@id": canonicalURL.href },
+  author: {
+    "@type": "Person",
+    name: "Andy Grunwald",
+    url: "https://andygrunwald.com/",
+  },
+};
 ---
 
 <!doctype html>
@@ -50,6 +68,7 @@ if (resolvedImage) {
       {canonicalURL}
       ogType="article"
     />
+    <JsonLd schema={blogPostingSchema} />
   </head>
   <body class="antialiased bg-body text-body font-body">
     <div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,11 +4,18 @@ import MainHead from "../components/MainHead.astro";
 import Nav from "../components/Nav.astro";
 import Footer from "../components/Footer.astro";
 import portrait from "../assets/images/andy-grunwald.png";
+import JsonLd from "../components/JsonLd.astro";
+import { personSchema } from "../scripts/structured-data.js";
 
 let title = "Andy Grunwald - Software Engineer and Engineering Manager";
 let description =
   "Software Engineer and Engineering Manager. Open Source enthusiast with a passion for Backend, Infrastructure, Reliability and Engineering Culture.";
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+
+const aboutSchema = {
+  "@context": "https://schema.org",
+  ...personSchema,
+};
 ---
 
 <!doctype html>
@@ -20,6 +27,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       image="/images/andy-grunwald-opengraph.png"
       {canonicalURL}
     />
+    <JsonLd schema={aboutSchema} />
   </head>
   <body class="antialiased bg-body text-body font-body">
     <div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,11 +3,18 @@ import MainHead from "../components/MainHead.astro";
 import Nav from "../components/Nav.astro";
 import Footer from "../components/Footer.astro";
 import BlogPostPreviewListing from "../components/BlogPostPreviewListing.astro";
+import JsonLd from "../components/JsonLd.astro";
+import { personSchema, webSiteSchema } from "../scripts/structured-data.js";
 
 let title = "Andy Grunwald - Software Engineer and Engineering Manager";
 let description =
   "Software Engineer and Engineering Manager. Open Source enthusiast with a passion for Backend, Infrastructure, Reliability and Engineering Culture.";
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+
+const homeSchema = {
+  "@context": "https://schema.org",
+  "@graph": [personSchema, webSiteSchema],
+};
 ---
 
 <!doctype html>
@@ -19,6 +26,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       image="/images/andy-grunwald-opengraph.png"
       {canonicalURL}
     />
+    <JsonLd schema={homeSchema} />
   </head>
   <body class="antialiased bg-body text-body font-body">
     <div>

--- a/src/scripts/structured-data.js
+++ b/src/scripts/structured-data.js
@@ -1,0 +1,26 @@
+// Shared schema.org building blocks for JSON-LD structured data.
+const SITE_URL = "https://andygrunwald.com/";
+
+export const personSchema = {
+  "@type": "Person",
+  name: "Andy Grunwald",
+  url: SITE_URL,
+  jobTitle: "Engineering Manager",
+  worksFor: {
+    "@type": "Organization",
+    name: "Cloudflare",
+    url: "https://www.cloudflare.com/",
+  },
+  sameAs: [
+    "https://x.com/andygrunwald",
+    "https://hachyderm.io/@andygrunwald",
+    "https://github.com/andygrunwald",
+    "https://www.linkedin.com/in/andy-grunwald-09aa265a/",
+  ],
+};
+
+export const webSiteSchema = {
+  "@type": "WebSite",
+  name: "Andy Grunwald",
+  url: SITE_URL,
+};


### PR DESCRIPTION
Emit schema.org structured data so search engines can build richer results:

- **`BlogPosting`** on every blog post (author, `datePublished`/`dateModified`, `keywords`, absolutized image, canonical URL).
- **`Person`** + **`WebSite`** `@graph` on the homepage, with the same `Person` reused on the about page.
- A small **`JsonLd`** component serializes the schema and escapes `<` (→ `<`) so the JSON can never break out of the `<script>` element.
- Shared building blocks live in `src/scripts/structured-data.js`.

This applies the previously-stranded commit from `andygrunwald/astro-best-practices` onto current `main`. Image-optimization changes on `main` had rewritten the touched `.astro` files, so the cherry-pick required resolving a conflict in `blog-post.astro` (schema block re-anchored after the new `resolvedImage`/`metaTagImage` logic) and `about.astro` (kept both the optimized `portrait` import and the new JSON-LD imports).

## Verification
- `npm run build` ✓ — 30 pages built
- Rendered JSON-LD confirmed in built output for the homepage (`Person`+`WebSite`), about (`Person`), and a blog post (`BlogPosting`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)