### PR TITLE
Widen blog article detail view to max-w-3xl

### DIFF
--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -76,7 +76,7 @@ const blogPostingSchema = {
 
       <section class="relative py-20">
         <div class="container px-4 mx-auto">
-          <div class="max-w-2xl mx-auto mb-10 text-center">
+          <div class="max-w-3xl mx-auto mb-10 text-center">
             <h1 class="mb-6 text-4xl font-semibold font-heading">
               {content.title}
             </h1>
@@ -110,7 +110,7 @@ const blogPostingSchema = {
             )
           }
 
-          <div class="max-w-2xl mx-auto">
+          <div class="max-w-3xl mx-auto">
             <article>
               <slot />
             </article>


### PR DESCRIPTION
The blog post detail page constrained its content to max-w-2xl (672px), leaving a lot of unused horizontal space on either side. Widening the content column to max-w-3xl (768px) reclaims some of that space and improves the reading experience without pushing line length past a comfortable measure for the text-xl body copy.

The same width is applied to the centered title/date/category block so the column edges stay aligned with the article body.