### PR TITLE
Remove the .astro cache in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,10 @@ run: ## Starts the development server
 	npm run dev
 
 .PHONY: clean
-clean: ## Deletes the generated content and node_modules
+clean: ## Deletes the generated content, caches and node_modules
 	rm -rf ./dist
 	rm -rf ./node_modules
+	rm -rf ./.astro
 
 .PHONY: init
 init: ## Installs dependencies


### PR DESCRIPTION
`make clean` dropped `dist/` and `node_modules/` but left `.astro/` behind, so a "clean" checkout still carried a stale content-layer cache:

- `data-store.json` (223 KB) from 8 June
- `content.d.ts` predating the current `src/content.config.ts`
- `collections/*.schema.json` from December 2024
- ~500 KB of `fonts/` + `fonts.d.ts` generated by an `astro:fonts` experiment that was never merged (fonts are served from `/public/css/inter.css`)

None of this affects CI, which always starts from an empty checkout. Locally it means `make clean` does not actually give you a clean slate — exactly when you need one, such as before a dependency major upgrade.

## Verification

`make clean` now leaves no `.astro/`, `dist/` or `node_modules/`, and the full CI gate sequence passes on a fresh install under Node 24.19.0:

| Step | Result |
|---|---|
| `make init` | ok |
| `make format-check` | All matched files use Prettier code style! |
| `make lint` | clean |
| `make check` | Result (30 files): 0 errors, 0 warnings, 43 hints |
| `make build` | 30 page(s) built |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt