### PR TITLE
Emit ISO 8601 in the blog post time element

### DIFF
--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -83,7 +83,7 @@ const blogPostingSchema = {
             <div class="items-center justify-center">
               <div class="text-center mb-4">
                 <p class="text-gray-500">
-                  <time class="date" datetime={content.pubDate}
+                  <time class="date" datetime={content.pubDate.toISOString()}
                     >{formatDate(content.pubDate)}</time
                   >
                 </p>


### PR DESCRIPTION
`src/layouts/blog-post.astro` handed `<time>` the raw `Date` object, so it serialized through `Date.prototype.toString()` and baked the build machine's timezone and locale into the markup. All 26 built blog pages currently contain:

```html
<time class="date" datetime="Tue Jul 02 2019 02:00:00 GMT+0200 (Mitteleuropäische Sommerzeit)">
```

Two problems:

1. **It is not a valid `<time datetime>` value.** The HTML spec requires one of the datetime microsyntaxes, so anything machine-reading the date — search engines, feed readers, `structured-data` consumers — gets nothing usable.
2. **The build is not reproducible.** Two builds of the same commit on two machines produce different HTML across 26 pages, which makes the output impossible to diff and Netlify's cache invalidation noisier than it needs to be.

`src/components/BlogPostPreview.astro:33` already calls `.toISOString()` for the same value — this brings the layout in line.

```diff
-<time class="date" datetime={content.pubDate}
+<time class="date" datetime={content.pubDate.toISOString()}
```

## Verification

| Step | Result |
|---|---|
| `make format-check` | All matched files use Prettier code style! |
| `make lint` | clean |
| `make check` | Result (30 files): 0 errors, 0 warnings, 43 hints |
| `make build` | 30 page(s) built |

Comparing `dist/` against a build of `main` (both `TZ=UTC LC_ALL=C`): exactly **26 files differ — the 26 blog post pages — and every single difference is a `datetime` attribute value.** Normalizing that attribute away makes all 30 pages byte-identical.

```
- datetime="Tue Jul 02 2019 00:00:00 GMT+0000 (Coordinated Universal Time)">Tuesday, 2 July 2019
+ datetime="2019-07-02T00:00:00.000Z">Tuesday, 2 July 2019
```

The visible date text comes from `formatDate()` and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt