### PR TITLE
Remove the dead preconnect to fonts.gstatic.com

### DIFF
--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -31,7 +31,6 @@ if (ogType) {
   content="follow, index, max-snippet:-1, max-video-preview:-1, max-image-preview:large"
 />
 
-<link rel="preconnect" href="https://fonts.gstatic.com" />
 <link rel="stylesheet" href="/css/inter.css" />
 
 <link rel="sitemap" href="/sitemap-index.xml" />


### PR DESCRIPTION
## What

Deletes one line from `src/components/MainHead.astro`:

```html
<link rel="preconnect" href="https://fonts.gstatic.com" />
```

## Why

Every font on this site is self-hosted from `public/css/font-files/`. Nothing on any page ever requests `fonts.gstatic.com`, so this hint made the browser open a DNS + TCP + TLS handshake to an unused origin on every page load.

It went unnoticed because `.github/workflows/links.yml` explicitly excludes `fonts\.gstatic\.com` from the link checker.

## Verification

```
make format-check && make lint && make check && make build
grep -rl "fonts.gstatic.com" dist/   # no matches
```

Found during an Astro best-practice audit of the repo (P0 item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt