### PR TITLE
Give the two hero images a srcset and LCP priority

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,6 +11,13 @@ export default defineConfig({
     prefetchAll: true,
     defaultStrategy: "hover",
   },
+  image: {
+    // Emit a srcset for every <Image>. `responsiveStyles` is deliberately
+    // left at its default of false: Astro's responsive styles are not in a
+    // cascade layer, so they would override the Tailwind object-fit
+    // utilities this site uses on its images.
+    layout: "constrained",
+  },
   vite: {
     plugins: [tailwindcss()],
   },

--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -103,7 +103,7 @@ const blogPostingSchema = {
                 <Image
                   src={resolvedImage}
                   alt={content.title}
-                  loading="eager"
+                  priority
                   class="w-full h-full object-cover object-top rounded-lg"
                 />
               </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -93,6 +93,7 @@ const aboutSchema = {
                 class="lg:h-128 rounded-xl object-cover"
                 alt="Andy Grunwald"
                 title="Andy Grunwald"
+                priority
               />
             </div>
           </div>


### PR DESCRIPTION
## What

- `astro.config.mjs` — adds `image: { layout: "constrained" }`
- `src/pages/about.astro` — adds `priority` to the portrait
- `src/layouts/blog-post.astro` — replaces hand-written `loading="eager"` with `priority`

## Why

Both above-the-fold images were misconfigured, in opposite directions:

| | before |
|---|---|
| `/about/` portrait (the LCP element) | `loading="lazy"` |
| blog post header | `loading="eager"`, but no `fetchpriority="high"`, no `decoding="sync"` |
| **both** | **no `layout` → no `srcset`** — a phone downloaded the full 1200 px asset |

Astro's `priority` prop is the single built-in for this: it sets `loading="eager"` + `decoding="sync"` + `fetchpriority="high"` together. Setting `image.layout` globally fixes the missing `srcset` for every `<Image>` at once.

## Why `responsiveStyles` is deliberately NOT enabled

The docs' general advice is to turn it on, but there's a Tailwind v4 carve-out — Astro's responsive styles aren't in a cascade layer, so they always beat Tailwind utilities:

> To use Tailwind rules instead of Astro's default styling, do not enable Astro's default responsive styles.

`blog-post.astro` styles its header with `object-cover object-top`; enabling `responsiveStyles` would silently override them. Tailwind preflight already ships `img,video{max-width:100%;height:auto}`, so nothing is missing.

Verified in the build: `class="w-full h-full object-cover object-top rounded-lg"` survives, and `dist/_astro/*.css` contains **0** `data-astro-image` rules.

## Verification

Both heroes now emit:

```
srcset="…640w, 750w, 828w, 1080w, …"  loading="eager"  decoding="sync"  fetchpriority="high"
```

```
make format-check && make lint && make check && make build
```

## Note on output size

`dist/` grows 28 MB → 29 MB, because the two heroes now emit width variants. That's the intended tradeoff: each visitor downloads one appropriately-sized file instead of the largest one. Client JS unchanged (1 file).

Found during an Astro best-practice audit of the repo (P0 item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt