### PR TITLE
Emit per-post lastmod in the sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,47 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { slug as githubSlug } from "github-slugger";
+
 import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import sitemap from "@astrojs/sitemap";
 import mdx from "@astrojs/mdx";
+
+const BLOG_CONTENT_DIR = "./src/content/blog";
+
+// Maps a blog post slug to its `lastmod` frontmatter date.
+//
+// @astrojs/sitemap cannot read page frontmatter itself -- its top-level
+// `lastmod` option is site-wide only -- so the dates have to be collected here
+// and applied per entry in `serialize`. `astro:content` is not available inside
+// the config, hence reading the files directly.
+//
+// Slugs come from github-slugger because that is what Astro's glob loader uses
+// to turn a filename into an entry id. Filenames alone would not match: three
+// posts contain dots (`...php-7.2-setup-to-homebrew-v1.5.mdx`), which the
+// slugger strips.
+function readBlogPostLastmod() {
+  const lastmodBySlug = new Map();
+
+  for (const filename of readdirSync(BLOG_CONTENT_DIR)) {
+    if (!filename.endsWith(".mdx")) {
+      continue;
+    }
+
+    const source = readFileSync(join(BLOG_CONTENT_DIR, filename), "utf8");
+    const frontmatter = source.split("---", 2)[1] ?? "";
+    const lastmod = frontmatter.match(/^lastmod:\s*(\S+)/m)?.[1];
+
+    if (lastmod) {
+      lastmodBySlug.set(githubSlug(filename.replace(/\.mdx$/, "")), lastmod);
+    }
+  }
+
+  return lastmodBySlug;
+}
+
+const lastmodBySlug = readBlogPostLastmod();
 
 // https://astro.build/config
 export default defineConfig({
@@ -14,5 +54,27 @@ export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
   },
-  integrations: [sitemap(), mdx()],
+  integrations: [
+    sitemap({
+      serialize(item) {
+        const slug = item.url.match(/\/blog\/([^/]+)\/$/)?.[1];
+        const lastmod = slug && lastmodBySlug.get(slug);
+
+        if (lastmod) {
+          item.lastmod = lastmod;
+        }
+
+        return item;
+      },
+      // The site has no news, video, translated or image-annotated entries, so
+      // these namespaces only add bytes to every sitemap.
+      namespaces: {
+        news: false,
+        video: false,
+        xhtml: false,
+        image: false,
+      },
+    }),
+    mdx(),
+  ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.2.4",
         "astro-remote": "^0.3.4",
+        "github-slugger": "^2.0.0",
         "netlify-purge-cloudflare-on-deploy": "^1.2.0",
         "tailwindcss": "^4.3.3"
       },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.2.4",
     "astro-remote": "^0.3.4",
+    "github-slugger": "^2.0.0",
     "netlify-purge-cloudflare-on-deploy": "^1.2.0",
     "tailwindcss": "^4.3.3"
   },


### PR DESCRIPTION
## What

`astro.config.mjs` — adds a `serialize()` that attaches each post's `lastmod`, plus `namespaces` to drop four unused XML namespaces. Adds `github-slugger` as a dependency.

## Why

Every blog post carries a `lastmod` frontmatter field, but `dist/sitemap-0.xml` contained **zero** `<lastmod>` elements — `sitemap()` was called with no options. The frontmatter field described a fact nothing consumed, and crawlers had no signal about which of the 26 posts had changed.

`@astrojs/sitemap` can't read frontmatter itself. Its top-level `lastmod` option is **site-wide only**, and the docs are explicit that the integration *"can't analyze a given page's source code"*. So the dates have to be gathered in the config and applied per entry via `serialize()`.

## The slug wrinkle (worth a look during review)

My first attempt keyed the map on the raw filename. That silently missed **three** posts:

```
/blog/migrate-your-local-php-72-setup-to-homebrew-v15/   ← file: ...php-7.2-setup-to-homebrew-v1.5.mdx
/blog/typo3-analytics-release-of-version-v001/           ← file: ...v0.0.1.mdx
/blog/typo3-analytics-release-of-version-v010/           ← file: ...v0.1.0.mdx
```

Astro's glob loader runs each filename through `github-slugger` to produce the entry id, which strips the dots. Rather than reimplement that rule (and have it drift), the config now imports the same library Astro uses, so the keys match by construction.

## Result

| | before | after |
|---|---|---|
| `<lastmod>` elements | 0 | 26 |
| URLs | 29 | 29 |
| namespaces declared | 5 | 1 |

The three static pages (`/`, `/about/`, `/blog/`) correctly have no `lastmod` — there's no frontmatter to source it from.

## Verification

```
make format-check && make lint && make check && make build
grep -o '<lastmod>' dist/sitemap-0.xml | wc -l   # 26
grep -o '<url>' dist/sitemap-0.xml | wc -l       # 29
```

`dist/sitemap-0.xml` parses as well-formed XML.

Found during an Astro best-practice audit of the repo (P0 item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt