### PR TITLE
Run astro check as part of the build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -102,7 +102,7 @@ force = true
 
 [build]
 publish = "dist/"
-command = "astro build"
+command = "npm run build"
 
 [[plugins]]
 package = "netlify-purge-cloudflare-on-deploy"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "astro check && astro build",
     "preview": "astro preview",
     "check": "astro check",
     "format": "prettier --write .",


### PR DESCRIPTION
## What

- `package.json` — `"build": "astro check && astro build"`
- `netlify.toml` — `command = "astro build"` → `command = "npm run build"`

## Why

`astro check` ran only as its own step in GitHub Actions. Netlify built with a bare `astro build`, so **a type or content-schema error merged to `main` would still deploy** — the deploy path never consulted the checker CI had just run.

Both changes are needed: updating only `package.json` would leave Netlify calling `astro` directly and the gap open.

## Note

CI keeps its dedicated `make check` step, so the check now runs twice there (a few seconds). That's deliberate — it keeps a failure attributable to a named CI step instead of being buried inside the build step. Happy to drop it if you'd rather have the seconds back.

## Verification

```
npm run build   # now prints "[check] Getting diagnostics…" then "- 0 errors" before building
make format-check && make lint
```

First of the P1 items from the Astro best-practice audit. Stacked: subsequent P1 PRs build on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt