### PR TITLE
Import zod from astro/zod instead of astro:schema

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,5 @@
 import { defineCollection } from "astro:content";
-import { z } from "astro:schema";
+import { z } from "astro/zod";
 import { glob } from "astro/loaders";
 
 const blogPostsCollection = defineCollection({


### PR DESCRIPTION
## What

`src/content.config.ts`:

```diff
-import { z } from "astro:schema";
+import { z } from "astro/zod";
```

## Why

Astro 6 deprecated the `astro:schema` virtual module (and re-exporting `z` from `astro:content`) in favour of `astro/zod`. It still works today, but moving now avoids a forced change later.

No behaviour change: the collections use only `z.object`, `z.string`, `z.array`, `z.date` and `z.boolean`, which are identical across both entrypoints.

Worth knowing for later — Astro 6 also moved to **Zod 4**. Nothing here needs it, but if the `speaking`/`project` schemas get loosened, the Zod 4 spellings are `z.url()` (not `z.string().url()`) and `{ error: … }` (not `{ message: … }`).

## Verification

```
make lint && npm run build   # 0 errors, 30 pages
```

> **Stacked PR** — based on #597. Review just the top commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt