### PR TITLE
Introduce a BaseLayout and site constants

### DIFF
--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -1,20 +1,18 @@
 ---
 import "../styles/global.css";
 
-export interface Props {
+interface Props {
   title: string;
   description: string;
   image?: string;
-  canonicalURL?: string | URL;
   ogType?: string;
 }
 
-const { title, description, image, canonicalURL, ogType } =
-  Astro.props as Props;
-let ogTypeValue = "website";
-if (ogType) {
-  ogTypeValue = ogType;
-}
+const { title, description, image, ogType = "website" } = Astro.props;
+
+// Derived here rather than passed in: every caller computed the identical
+// expression, and Astro.url is available in this component anyway.
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 
 <meta charset="utf-8" />
@@ -50,7 +48,7 @@ if (ogType) {
 <link rel="canonical" href={canonicalURL} />
 
 <meta property="og:url" content={canonicalURL} />
-<meta property="og:type" content={ogTypeValue} />
+<meta property="og:type" content={ogType} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
 {image && <meta property="og:image" content={new URL(image, canonicalURL)} />}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,10 @@
+// Site-wide constants. These strings were previously duplicated across the
+// pages and the RSS endpoint, which let them drift independently.
+
+export const SITE_TITLE =
+  "Andy Grunwald - Software Engineer and Engineering Manager";
+
+export const SITE_DESCRIPTION =
+  "Software Engineer and Engineering Manager. Open Source enthusiast with a passion for Backend, Infrastructure, Reliability and Engineering Culture.";
+
+export const SITE_OG_IMAGE = "/images/andy-grunwald-opengraph.png";

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,35 @@
+---
+import MainHead from "../components/MainHead.astro";
+import Nav from "../components/Nav.astro";
+import Footer from "../components/Footer.astro";
+import { SITE_DESCRIPTION, SITE_OG_IMAGE } from "../consts";
+
+interface Props {
+  title: string;
+  description?: string;
+  image?: string;
+  ogType?: string;
+}
+
+const {
+  title,
+  description = SITE_DESCRIPTION,
+  image = SITE_OG_IMAGE,
+  ogType,
+} = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <MainHead {title} {description} {image} {ogType} />
+    <slot name="head" />
+  </head>
+  <body class="antialiased bg-body text-body font-body">
+    <div>
+      <Nav />
+      <slot />
+      <Footer />
+    </div>
+  </body>
+</html>

--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -1,12 +1,11 @@
 ---
 import { Image } from "astro:assets";
-import MainHead from "../components/MainHead.astro";
-import Nav from "../components/Nav.astro";
-import Footer from "../components/Footer.astro";
+import BaseLayout from "./BaseLayout.astro";
 import CategoryBadge from "../components/CategoryBadge.astro";
 import JsonLd from "../components/JsonLd.astro";
 import { formatDate } from "../scripts/date.js";
 import { resolvePostImage } from "../scripts/post-images.js";
+import { SITE_OG_IMAGE } from "../consts";
 
 import "../styles/blogpost.css";
 
@@ -14,7 +13,7 @@ const { blogPost } = Astro.props;
 const content = blogPost.data;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-let title = `${content.title} - Andy Grunwald`;
+const title = `${content.title} - Andy Grunwald`;
 
 // First frontmatter image, resolved to an optimized asset when it has been
 // migrated into src/ (null while still a /public path or absent).
@@ -33,7 +32,7 @@ if (content.showHeaderImage && firstImage) {
 
 // Open graph / Twitter card image: prefer the optimized asset's URL, then the
 // raw path, then the default site card. MainHead absolutizes it via new URL().
-let metaTagImage = "/images/andy-grunwald-opengraph.png";
+let metaTagImage = SITE_OG_IMAGE;
 if (resolvedImage) {
   metaTagImage = resolvedImage.src;
 } else if (firstImage) {
@@ -53,73 +52,60 @@ const blogPostingSchema = {
   author: {
     "@type": "Person",
     name: "Andy Grunwald",
-    url: "https://andygrunwald.com/",
+    url: Astro.site?.href,
   },
 };
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <MainHead
-      title={title}
-      description={content.description}
-      image={metaTagImage}
-      {canonicalURL}
-      ogType="article"
-    />
-    <JsonLd schema={blogPostingSchema} />
-  </head>
-  <body class="antialiased bg-body text-body font-body">
-    <div>
-      <Nav title={title} />
-
-      <section class="relative py-20">
-        <div class="container px-4 mx-auto">
-          <div class="max-w-3xl mx-auto mb-10 text-center">
-            <h1 class="mb-6 text-4xl font-semibold font-heading">
-              {content.title}
-            </h1>
-            <div class="items-center justify-center">
-              <div class="text-center mb-4">
-                <p class="text-gray-500">
-                  <time class="date" datetime={content.pubDate.toISOString()}
-                    >{formatDate(content.pubDate)}</time
-                  >
-                </p>
-              </div>
-              <div class="text-center">
-                {
-                  content.categories.map((category: string) => (
-                    <CategoryBadge category={category} />
-                  ))
-                }
-              </div>
-            </div>
+<BaseLayout
+  {title}
+  description={content.description}
+  image={metaTagImage}
+  ogType="article"
+>
+  <JsonLd slot="head" schema={blogPostingSchema} />
+  <section class="relative py-20">
+    <div class="container px-4 mx-auto">
+      <div class="max-w-3xl mx-auto mb-10 text-center">
+        <h1 class="mb-6 text-4xl font-semibold font-heading">
+          {content.title}
+        </h1>
+        <div class="items-center justify-center">
+          <div class="text-center mb-4">
+            <p class="text-gray-500">
+              <time class="date" datetime={content.pubDate.toISOString()}
+                >{formatDate(content.pubDate)}</time
+              >
+            </p>
           </div>
-          {
-            hasImage && (
-              <div class="h-112 mb-10">
-                <Image
-                  src={resolvedImage}
-                  alt={content.title}
-                  priority
-                  class="w-full h-full object-cover object-top rounded-lg"
-                />
-              </div>
-            )
-          }
-
-          <div class="max-w-3xl mx-auto">
-            <article>
-              <slot />
-            </article>
-            <hr />
+          <div class="text-center">
+            {
+              content.categories.map((category: string) => (
+                <CategoryBadge category={category} />
+              ))
+            }
           </div>
         </div>
-      </section>
+      </div>
+      {
+        hasImage && (
+          <div class="h-112 mb-10">
+            <Image
+              src={resolvedImage}
+              alt={content.title}
+              priority
+              class="w-full h-full object-cover object-top rounded-lg"
+            />
+          </div>
+        )
+      }
 
-      <Footer />
+      <div class="max-w-3xl mx-auto">
+        <article>
+          <slot />
+        </article>
+        <hr />
+      </div>
     </div>
-  </body>
-</html>
+  </section>
+</BaseLayout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,44 +1,29 @@
 ---
-import MainHead from "../components/MainHead.astro";
-import Nav from "../components/Nav.astro";
-import Footer from "../components/Footer.astro";
-
-let title = "Page not found - Andy Grunwald";
-let description = "The page you are looking for could not be found.";
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <MainHead title={title} description={description} {canonicalURL} />
-  </head>
-  <body class="antialiased bg-body text-body font-body">
-    <div>
-      <Nav title={title} />
-
-      <section class="relative py-20">
-        <div class="container px-4 mx-auto text-center">
-          <span class="text-blue-400 font-semibold text-3xl">404</span>
-          <h1 class="mt-8 mb-6 text-4xl lg:text-6xl font-semibold">
-            This page could not be found.
-          </h1>
-          <p class="max-w-2xl mx-auto mb-8 text-xl text-gray-500">
-            The page you are looking for might have been moved, renamed, or
-            never existed.
-          </p>
-          <a
-            class="inline-block w-full md:w-auto mb-2 md:mb-0 px-8 py-4 mr-4 text-sm font-medium leading-normal bg-red-400 hover:bg-red-300 text-white rounded transition duration-200"
-            href="/">Back to the homepage</a
-          >
-          <a
-            class="inline-block w-full md:w-auto px-8 py-4 text-sm font-medium leading-normal bg-gray-50 hover:bg-gray-100 text-gray-900 rounded transition duration-200"
-            href="/blog/">Read the blog</a
-          >
-        </div>
-      </section>
-
-      <Footer />
+<BaseLayout
+  title="Page not found - Andy Grunwald"
+  description="The page you are looking for could not be found."
+>
+  <section class="relative py-20">
+    <div class="container px-4 mx-auto text-center">
+      <span class="text-blue-400 font-semibold text-3xl">404</span>
+      <h1 class="mt-8 mb-6 text-4xl lg:text-6xl font-semibold">
+        This page could not be found.
+      </h1>
+      <p class="max-w-2xl mx-auto mb-8 text-xl text-gray-500">
+        The page you are looking for might have been moved, renamed, or never
+        existed.
+      </p>
+      <a
+        class="inline-block w-full md:w-auto mb-2 md:mb-0 px-8 py-4 mr-4 text-sm font-medium leading-normal bg-red-400 hover:bg-red-300 text-white rounded transition duration-200"
+        href="/">Back to the homepage</a
+      >
+      <a
+        class="inline-block w-full md:w-auto px-8 py-4 text-sm font-medium leading-normal bg-gray-50 hover:bg-gray-100 text-gray-900 rounded transition duration-200"
+        href="/blog/">Read the blog</a
+      >
     </div>
-  </body>
-</html>
+  </section>
+</BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,16 +1,10 @@
 ---
 import { Image } from "astro:assets";
-import MainHead from "../components/MainHead.astro";
-import Nav from "../components/Nav.astro";
-import Footer from "../components/Footer.astro";
+import BaseLayout from "../layouts/BaseLayout.astro";
 import portrait from "../assets/images/andy-grunwald.png";
 import JsonLd from "../components/JsonLd.astro";
 import { personSchema } from "../scripts/structured-data.js";
-
-let title = "Andy Grunwald - Software Engineer and Engineering Manager";
-let description =
-  "Software Engineer and Engineering Manager. Open Source enthusiast with a passion for Backend, Infrastructure, Reliability and Engineering Culture.";
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+import { SITE_TITLE } from "../consts";
 
 const aboutSchema = {
   "@context": "https://schema.org",
@@ -18,89 +12,70 @@ const aboutSchema = {
 };
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <MainHead
-      title={title}
-      description={description}
-      image="/images/andy-grunwald-opengraph.png"
-      {canonicalURL}
-    />
-    <JsonLd schema={aboutSchema} />
-  </head>
-  <body class="antialiased bg-body text-body font-body">
-    <div>
-      <Nav title={title} />
-
-      <section class="relative py-20">
-        <div class="relative container px-4 mx-auto">
-          <div class="flex flex-wrap items-center -mx-4">
-            <div class="w-full lg:w-1/2 px-4 mb-12 lg:mb-0">
-              <div class="max-w-lg">
-                <span class="text-xs text-blue-400 font-semibold">
-                  Who is Andy?
-                </span>
-                <h1 class="mt-8 mb-6 lg:mb-10 lg:pr-8 text-4xl font-semibold">
-                  Andy Grunwald
-                </h1>
-                <p class="mb-6 lg:mb-6 text-xl text-gray-500">
-                  I’m an open source enthusiast with a passion for Backend,
-                  Infrastructure, Reliability and Engineering Culture.
-                </p>
-                <p class="mb-6 lg:mb-6 text-xl text-gray-500">
-                  I am working at <a
-                    href="https://www.cloudflare.com/"
-                    title="Cloudflare"
-                    class="text-red-500 underline hover:no-underline"
-                    >Cloudflare</a
-                  > as an Engineering Manager, leading teams of engineers.
-                </p>
-                <p class="mb-6 lg:mb-6 text-xl text-gray-500">
-                  I enjoy running side projects to learn new things. Nowadays, I
-                  am talking about Software Engineering in the <a
-                    href="https://engineeringkiosk.dev/"
-                    title="Engineering Kiosk - Der deutschsprachige Software-Engineering-Podcast"
-                    class="text-red-500 underline hover:no-underline"
-                    >Engineering Kiosk Podcast</a
-                  >{" "}
-                  and building <a
-                    href="https://sourcectl.dev/"
-                    title="sourcectl - A data driven approach for your Open Source and Inner Source environment"
-                    class="text-red-500 underline hover:no-underline"
-                    >sourcectl</a
-                  >, a platform to analyze and improve your open source and
-                  inner source environment.
-                </p>
-                <p class="mb-6 lg:mb-6 text-xl text-gray-500">
-                  In the past, I was the primary organizer of the <a
-                    href="https://www.meetup.com/web-engineering-duesseldorf/"
-                    title="Web Engineering Meetup Düsseldorf - WebEngDUS"
-                    class="text-red-500 underline hover:no-underline"
-                    >Web Engineering Meetup Düsseldorf</a
-                  > (2012 - 2023) and organized the <a
-                    href="https://localhost.engineering/"
-                    title="localhost conference - A conference for people who create the internet"
-                    class="text-red-500 underline hover:no-underline"
-                    >localhost conference</a
-                  > (2019).
-                </p>
-              </div>
-            </div>
-            <div class="relative w-full lg:w-1/2 px-4">
-              <Image
-                src={portrait}
-                class="lg:h-128 rounded-xl object-cover"
-                alt="Andy Grunwald"
-                title="Andy Grunwald"
-                priority
-              />
-            </div>
+<BaseLayout title={SITE_TITLE}>
+  <JsonLd slot="head" schema={aboutSchema} />
+  <section class="relative py-20">
+    <div class="relative container px-4 mx-auto">
+      <div class="flex flex-wrap items-center -mx-4">
+        <div class="w-full lg:w-1/2 px-4 mb-12 lg:mb-0">
+          <div class="max-w-lg">
+            <span class="text-xs text-blue-400 font-semibold">
+              Who is Andy?
+            </span>
+            <h1 class="mt-8 mb-6 lg:mb-10 lg:pr-8 text-4xl font-semibold">
+              Andy Grunwald
+            </h1>
+            <p class="mb-6 lg:mb-6 text-xl text-gray-500">
+              I’m an open source enthusiast with a passion for Backend,
+              Infrastructure, Reliability and Engineering Culture.
+            </p>
+            <p class="mb-6 lg:mb-6 text-xl text-gray-500">
+              I am working at <a
+                href="https://www.cloudflare.com/"
+                title="Cloudflare"
+                class="text-red-500 underline hover:no-underline">Cloudflare</a
+              > as an Engineering Manager, leading teams of engineers.
+            </p>
+            <p class="mb-6 lg:mb-6 text-xl text-gray-500">
+              I enjoy running side projects to learn new things. Nowadays, I am
+              talking about Software Engineering in the <a
+                href="https://engineeringkiosk.dev/"
+                title="Engineering Kiosk - Der deutschsprachige Software-Engineering-Podcast"
+                class="text-red-500 underline hover:no-underline"
+                >Engineering Kiosk Podcast</a
+              >{" "}
+              and building <a
+                href="https://sourcectl.dev/"
+                title="sourcectl - A data driven approach for your Open Source and Inner Source environment"
+                class="text-red-500 underline hover:no-underline">sourcectl</a
+              >, a platform to analyze and improve your open source and inner
+              source environment.
+            </p>
+            <p class="mb-6 lg:mb-6 text-xl text-gray-500">
+              In the past, I was the primary organizer of the <a
+                href="https://www.meetup.com/web-engineering-duesseldorf/"
+                title="Web Engineering Meetup Düsseldorf - WebEngDUS"
+                class="text-red-500 underline hover:no-underline"
+                >Web Engineering Meetup Düsseldorf</a
+              > (2012 - 2023) and organized the <a
+                href="https://localhost.engineering/"
+                title="localhost conference - A conference for people who create the internet"
+                class="text-red-500 underline hover:no-underline"
+                >localhost conference</a
+              > (2019).
+            </p>
           </div>
         </div>
-      </section>
-
-      <Footer />
+        <div class="relative w-full lg:w-1/2 px-4">
+          <Image
+            src={portrait}
+            class="lg:h-128 rounded-xl object-cover"
+            alt="Andy Grunwald"
+            title="Andy Grunwald"
+            priority
+          />
+        </div>
+      </div>
     </div>
-  </body>
-</html>
+  </section>
+</BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,32 +1,11 @@
 ---
-import MainHead from "../../components/MainHead.astro";
-import Nav from "../../components/Nav.astro";
-import Footer from "../../components/Footer.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 import BlogPostPreviewListing from "../../components/BlogPostPreviewListing.astro";
 
-let title = "Blog by Andy Grunwald - Software Engineer and Engineering Manager";
-let description =
-  "Software Engineer and Engineering Manager. Open Source enthusiast with a passion for Backend, Infrastructure, Reliability and Engineering Culture.";
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const title =
+  "Blog by Andy Grunwald - Software Engineer and Engineering Manager";
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <MainHead
-      title={title}
-      description={description}
-      image="/images/andy-grunwald-opengraph.png"
-      {canonicalURL}
-    />
-  </head>
-  <body class="antialiased bg-body text-body font-body">
-    <div>
-      <Nav title={title} />
-
-      <BlogPostPreviewListing numberOfItems={0} />
-
-      <Footer />
-    </div>
-  </body>
-</html>
+<BaseLayout {title}>
+  <BlogPostPreviewListing numberOfItems={0} />
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,15 +1,9 @@
 ---
-import MainHead from "../components/MainHead.astro";
-import Nav from "../components/Nav.astro";
-import Footer from "../components/Footer.astro";
+import BaseLayout from "../layouts/BaseLayout.astro";
 import BlogPostPreviewListing from "../components/BlogPostPreviewListing.astro";
 import JsonLd from "../components/JsonLd.astro";
 import { personSchema, webSiteSchema } from "../scripts/structured-data.js";
-
-let title = "Andy Grunwald - Software Engineer and Engineering Manager";
-let description =
-  "Software Engineer and Engineering Manager. Open Source enthusiast with a passion for Backend, Infrastructure, Reliability and Engineering Culture.";
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+import { SITE_TITLE } from "../consts";
 
 const homeSchema = {
   "@context": "https://schema.org",
@@ -17,54 +11,37 @@ const homeSchema = {
 };
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <MainHead
-      title={title}
-      description={description}
-      image="/images/andy-grunwald-opengraph.png"
-      {canonicalURL}
-    />
-    <JsonLd schema={homeSchema} />
-  </head>
-  <body class="antialiased bg-body text-body font-body">
-    <div>
-      <Nav title={title} />
-
-      <section class="relative pb-20">
-        <div class="relative container pt-12 px-4 mx-auto text-center">
-          <h1>
-            <span class="text-blue-400 font-semibold text-3xl">
-              Andy Grunwald
-            </span>
-            <div class="mt-8 mb-8 lg:mb-12 text-4xl lg:text-6xl font-semibold">
-              Engineering Manager and Software Engineer.
-            </div>
-          </h1>
-          <p class="max-w-3xl mx-auto mb-8 lg:mb-12 text-xl text-gray-500">
-            I manage engineers at <a
-              href="https://www.cloudflare.com/"
-              class="hover:underline text-red-300"
-              title="Cloudflare">Cloudflare</a
-            > and talk about Software Engineering in the <a
-              href="https://engineeringkiosk.dev/"
-              class="hover:underline text-red-300"
-              title="Engineering Kiosk Podcast">Engineering Kiosk Podcast</a
-            >.
-          </p>
-          <a
-            class="inline-block w-full md:w-auto mb-2 md:mb-0 px-8 py-4 mr-4 text-sm font-medium leading-normal bg-red-400 hover:bg-red-300 text-white rounded transition duration-200"
-            href="/#blog"
-          >
-            Checkout my articles
-          </a>
+<BaseLayout title={SITE_TITLE}>
+  <JsonLd slot="head" schema={homeSchema} />
+  <section class="relative pb-20">
+    <div class="relative container pt-12 px-4 mx-auto text-center">
+      <h1>
+        <span class="text-blue-400 font-semibold text-3xl">
+          Andy Grunwald
+        </span>
+        <div class="mt-8 mb-8 lg:mb-12 text-4xl lg:text-6xl font-semibold">
+          Engineering Manager and Software Engineer.
         </div>
-      </section>
-
-      <BlogPostPreviewListing numberOfItems={3} />
-
-      <Footer />
+      </h1>
+      <p class="max-w-3xl mx-auto mb-8 lg:mb-12 text-xl text-gray-500">
+        I manage engineers at <a
+          href="https://www.cloudflare.com/"
+          class="hover:underline text-red-300"
+          title="Cloudflare">Cloudflare</a
+        > and talk about Software Engineering in the <a
+          href="https://engineeringkiosk.dev/"
+          class="hover:underline text-red-300"
+          title="Engineering Kiosk Podcast">Engineering Kiosk Podcast</a
+        >.
+      </p>
+      <a
+        class="inline-block w-full md:w-auto mb-2 md:mb-0 px-8 py-4 mr-4 text-sm font-medium leading-normal bg-red-400 hover:bg-red-300 text-white rounded transition duration-200"
+        href="/#blog"
+      >
+        Checkout my articles
+      </a>
     </div>
-  </body>
-</html>
+  </section>
+
+  <BlogPostPreviewListing numberOfItems={3} />
+</BaseLayout>


### PR DESCRIPTION
## What

- new `src/layouts/BaseLayout.astro` — owns the document shell, exposes a `head` slot
- new `src/consts.ts` — `SITE_TITLE`, `SITE_DESCRIPTION`, `SITE_OG_IMAGE`
- `MainHead.astro` — derives `canonicalURL` itself; drops the `as Props` cast and the manual `ogType` default
- all four pages + `blog-post.astro` rewritten onto `BaseLayout`

## Why

The document shell — `<!doctype html>`, `<html lang="en">`, `<head><MainHead …/>`, `<body class="antialiased bg-body text-body font-body">`, `<Nav>`, `<Footer>` — was copy-pasted **five times**. Alongside it:

| Duplicated | Copies |
|---|---|
| `new URL(Astro.url.pathname, Astro.site)` | 5 |
| site description string | 4 |
| `https://andygrunwald.com/` hardcoded | 3 |

`MainHead` has `Astro.url` available, so every caller was computing an expression the component could derive itself. The post JSON-LD's author URL now comes from `Astro.site` instead of a fourth hardcoded copy of the domain.

`Nav` also no longer receives `title` — it never read `Astro.props`, so all five call sites were passing a value into a void.

## Proof this is a pure refactor

Built `main` and this branch, then compared every emitted `.html` and `.xml` token by token. Across all 30 pages there are exactly **two** classes of difference:

```
 30x  -<link rel="stylesheet" href="/_astro/Footer.BhSmTkd5.css">
 30x  +<link rel="stylesheet" href="/_astro/BaseLayout.BhSmTkd5.css">
  4x  (404.html only) gains og:image, twitter:image, twitter:card=summary_large_image
```

- The stylesheet is **byte-identical** (`cmp` clean) — same content hash `BhSmTkd5`, only the entry name changed.
- `rss.xml` and `sitemap-0.xml` are byte-identical.

**The one intentional behaviour change:** the 404 page now carries the site card image, because `BaseLayout` supplies `SITE_OG_IMAGE` by default and `404.astro` previously passed none. Harmless, and arguably right. Say the word if you'd rather keep 404 card-less and I'll special-case it.

## Verification

```
make format-check && make lint && npm run build
```

> **Stacked PR** — based on #599. Review just the top commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt