### PR TITLE
Move the build-time helpers to TypeScript

### DIFF
--- a/src/components/BlogPostImage.astro
+++ b/src/components/BlogPostImage.astro
@@ -1,6 +1,6 @@
 ---
 import { Image } from "astro:assets";
-import { resolvePostImage } from "../scripts/post-images.js";
+import { resolvePostImage } from "../lib/post-images";
 
 export interface Props {
   path: string;

--- a/src/components/BlogPostPreview.astro
+++ b/src/components/BlogPostPreview.astro
@@ -7,7 +7,7 @@ export interface Props {
   n: number;
 }
 import CategoryBadge from "./CategoryBadge.astro";
-import { formatDate } from "../scripts/date.js";
+import { formatDate } from "../lib/date";
 
 const { post } = Astro.props;
 ---

--- a/src/components/BlogPostPreviewListing.astro
+++ b/src/components/BlogPostPreviewListing.astro
@@ -1,6 +1,6 @@
 ---
 import BlogPostPreview from "../components/BlogPostPreview.astro";
-import { getSortedBlogPosts } from "../scripts/blog.js";
+import { getSortedBlogPosts } from "../lib/blog";
 
 export interface Props {
   // Number of items to show in the listing

--- a/src/components/Figure.astro
+++ b/src/components/Figure.astro
@@ -1,6 +1,6 @@
 ---
 import { Image } from "astro:assets";
-import { resolvePostImage } from "../scripts/post-images.js";
+import { resolvePostImage } from "../lib/post-images";
 
 export interface Props {
   path: string;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,5 @@
 ---
-import { navigationLinks } from "../scripts/navigation.js";
+import { navigationLinks } from "../lib/navigation";
 // Static website footer year
 const year = new Date().getFullYear();
 ---

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,5 +1,5 @@
 ---
-import { navigationLinks } from "../scripts/navigation.js";
+import { navigationLinks } from "../lib/navigation";
 const year = new Date().getFullYear();
 ---
 

--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -3,11 +3,16 @@ import { Image } from "astro:assets";
 import BaseLayout from "./BaseLayout.astro";
 import CategoryBadge from "../components/CategoryBadge.astro";
 import JsonLd from "../components/JsonLd.astro";
-import { formatDate } from "../scripts/date.js";
-import { resolvePostImage } from "../scripts/post-images.js";
+import { formatDate } from "../lib/date";
+import { resolvePostImage } from "../lib/post-images";
 import { SITE_OG_IMAGE } from "../consts";
+import type { CollectionEntry } from "astro:content";
 
 import "../styles/blogpost.css";
+
+interface Props {
+  blogPost: CollectionEntry<"blog">;
+}
 
 const { blogPost } = Astro.props;
 const content = blogPost.data;
@@ -20,12 +25,14 @@ const title = `${content.title} - Andy Grunwald`;
 const firstImage = content.images.length > 0 ? content.images[0] : null;
 const resolvedImage = firstImage ? await resolvePostImage(firstImage) : null;
 
-let hasImage = false;
+// Gate on the resolved asset, not the raw path: an unresolvable path used to
+// reach <Image> as null, which the types now reject outright.
+const headerImage = content.showHeaderImage ? resolvedImage : null;
+
 // Pre-existing, currently unused layout helpers (kept, marked intentional).
 let _imageWidthClass = "";
 let _imagePaddingLeftClass = "";
-if (content.showHeaderImage && firstImage) {
-  hasImage = true;
+if (headerImage) {
   _imageWidthClass = "lg:w-2/5";
   _imagePaddingLeftClass = "lg:pl-10";
 }
@@ -80,7 +87,7 @@ const blogPostingSchema = {
           </div>
           <div class="text-center">
             {
-              content.categories.map((category: string) => (
+              content.categories.map((category) => (
                 <CategoryBadge category={category} />
               ))
             }
@@ -88,10 +95,10 @@ const blogPostingSchema = {
         </div>
       </div>
       {
-        hasImage && (
+        headerImage && (
           <div class="h-112 mb-10">
             <Image
-              src={resolvedImage}
+              src={headerImage}
               alt={content.title}
               priority
               class="w-full h-full object-cover object-top rounded-lg"

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,7 @@
+import { getCollection, type CollectionEntry } from "astro:content";
+
+export async function getSortedBlogPosts(): Promise<CollectionEntry<"blog">[]> {
+  return (await getCollection("blog")).sort(
+    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+  );
+}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,11 +1,11 @@
-const options = {
+const options: Intl.DateTimeFormatOptions = {
   weekday: "long",
   year: "numeric",
   month: "long",
   day: "numeric",
 };
 
-export function formatDate(date) {
+export function formatDate(date: Date | string | null | undefined): string {
   if (!date) return "";
   const d = new Date(date);
   if (isNaN(d.getTime())) return "";

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,4 +1,10 @@
-export const navigationLinks = [
+export interface NavigationLink {
+  label: string;
+  href: string;
+  title: string;
+}
+
+export const navigationLinks: NavigationLink[] = [
   { label: "✍️ Blog", href: "/blog/", title: "Blog of Andy Grunwald" },
   { label: "👨‍🔬 About", href: "/about/", title: "About Andy Grunwald" },
   {

--- a/src/lib/post-images.ts
+++ b/src/lib/post-images.ts
@@ -5,11 +5,13 @@
 // entries and inline <Figure>/<BlogPostImage> `path=` attributes use this same
 // form, so a single resolver covers both. Returns null when the path is not a
 // processed asset (e.g. a not-yet-migrated post still pointing at /public).
-const assets = import.meta.glob(
+const assets = import.meta.glob<{ default: ImageMetadata }>(
   "/src/assets/images/posts/**/*.{png,jpg,jpeg,webp,gif}",
 );
 
-export async function resolvePostImage(path) {
+export async function resolvePostImage(
+  path: string,
+): Promise<ImageMetadata | null> {
   const loader = assets[path];
   if (!loader) {
     return null;

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -17,10 +17,10 @@ export const personSchema = {
     "https://github.com/andygrunwald",
     "https://www.linkedin.com/in/andy-grunwald-09aa265a/",
   ],
-};
+} as const;
 
 export const webSiteSchema = {
   "@type": "WebSite",
   name: "Andy Grunwald",
   url: SITE_URL,
-};
+} as const;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,7 +3,7 @@ import { Image } from "astro:assets";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import portrait from "../assets/images/andy-grunwald.png";
 import JsonLd from "../components/JsonLd.astro";
-import { personSchema } from "../scripts/structured-data.js";
+import { personSchema } from "../lib/structured-data";
 import { SITE_TITLE } from "../consts";
 
 const aboutSchema = {

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from "astro:content";
 import MarkdownPostLayout from "../../layouts/blog-post.astro";
+import type { InferGetStaticPropsType } from "astro";
 
 export async function getStaticPaths() {
   const blogEntries = await getCollection("blog");
@@ -10,7 +11,10 @@ export async function getStaticPaths() {
   }));
 }
 
-const { entry } = Astro.props;
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+
+const { entry }: Props = Astro.props;
+
 const { Content } = await render(entry);
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import BlogPostPreviewListing from "../components/BlogPostPreviewListing.astro";
 import JsonLd from "../components/JsonLd.astro";
-import { personSchema, webSiteSchema } from "../scripts/structured-data.js";
+import { personSchema, webSiteSchema } from "../lib/structured-data";
 import { SITE_TITLE } from "../consts";
 
 const homeSchema = {

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,5 +1,5 @@
 import rss from "@astrojs/rss";
-import { getSortedBlogPosts } from "../scripts/blog.js";
+import { getSortedBlogPosts } from "../lib/blog";
 
 export async function GET(context) {
   const blogPosts = await getSortedBlogPosts();

--- a/src/scripts/blog.js
+++ b/src/scripts/blog.js
@@ -1,7 +1,0 @@
-import { getCollection } from "astro:content";
-
-export async function getSortedBlogPosts() {
-  return (await getCollection("blog")).sort(
-    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-  );
-}


### PR DESCRIPTION
## What

- `src/scripts/` → `src/lib/`, all five `.js` → `.ts` with real types
- `blog-post.astro` and `blog/[...slug].astro` gain `Props` interfaces
- fixes a latent build crash the types exposed

## Why

The helpers were plain JavaScript in a project extending `astro/tsconfigs/strict`, so `astro check` gave them zero coverage and everything they returned crossed into `.astro` files untyped. The directory name was also misleading — in Astro convention `src/scripts/` means *client-side* scripts; these run at build time.

## The typing found a real bug

Adding the return type to `resolvePostImage` produced this immediately:

```
src/layouts/blog-post.astro:94:15 - error ts(2322):
Type 'ImageMetadata | null' is not assignable to type 'string | ImageMetadata | …'
```

The render guard tested the raw frontmatter path:

```js
if (content.showHeaderImage && firstImage) { hasImage = true; … }
{ hasImage && (<Image src={resolvedImage} … />) }   // ← different value!
```

So a post with `showHeaderImage: true` and an unresolvable image path would have reached `<Image src={null}>` and failed the build with an opaque error. It stayed hidden only because the one post in that state (`why-does-storing-two-factor-…`) has `images: []`.

The guard now tests the value that actually gets rendered.

## Also

The layout's lone inline `(category: string)` annotation is gone — it was compensating for the missing `Props` type.

`allowJs` stays in `tsconfig.json`: content collections require it, and `src/pages/rss.xml.js` is still JavaScript. Converting that one is deliberately left out to avoid a harder conflict with #595, which rewrites it.

## Verification

```
make format-check && make lint && npm run build   # 0 errors
```

Build output is **byte-identical** to the previous stack step — verified by token-level diff of every emitted `.html` and `.xml`.

> **Stacked PR** — based on #600. Review just the top commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt