### PR TITLE
Complete the head metadata and cover the blog listing

### DIFF
--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -1,4 +1,6 @@
 ---
+import { SITE_NAME } from "../consts";
+
 import "../styles/global.css";
 
 interface Props {
@@ -6,9 +8,18 @@ interface Props {
   description: string;
   image?: string;
   ogType?: string;
+  publishedTime?: Date;
+  modifiedTime?: Date;
 }
 
-const { title, description, image, ogType = "website" } = Astro.props;
+const {
+  title,
+  description,
+  image,
+  ogType = "website",
+  publishedTime,
+  modifiedTime,
+} = Astro.props;
 
 // Derived here rather than passed in: every caller computed the identical
 // expression, and Astro.url is available in this component anyway.
@@ -22,6 +33,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 />
 
 <title>{title}</title>
+<meta name="generator" content={Astro.generator} />
 <meta name="description" content={description} />
 
 <meta
@@ -44,19 +56,40 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
 <link rel="manifest" href="/site.webmanifest" />
+<meta name="theme-color" content="#ffffff" />
 
 <link rel="canonical" href={canonicalURL} />
 
 <meta property="og:url" content={canonicalURL} />
 <meta property="og:type" content={ogType} />
+<meta property="og:site_name" content={SITE_NAME} />
+<meta property="og:locale" content="en_GB" />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
 {image && <meta property="og:image" content={new URL(image, canonicalURL)} />}
+{image && <meta property="og:image:alt" content={title} />}
+{
+  publishedTime && (
+    <meta
+      property="article:published_time"
+      content={publishedTime.toISOString()}
+    />
+  )
+}
+{
+  modifiedTime && (
+    <meta
+      property="article:modified_time"
+      content={modifiedTime.toISOString()}
+    />
+  )
+}
 
 <meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
 <meta property="twitter:domain" content={Astro.site?.host} />
 <meta property="twitter:url" content={canonicalURL} />
 <meta name="twitter:site" content="@andygrunwald" />
+<meta name="twitter:creator" content="@andygrunwald" />
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={description} />
 {image && <meta name="twitter:image" content={new URL(image, canonicalURL)} />}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,6 +1,8 @@
 // Site-wide constants. These strings were previously duplicated across the
 // pages and the RSS endpoint, which let them drift independently.
 
+export const SITE_NAME = "Andy Grunwald";
+
 export const SITE_TITLE =
   "Andy Grunwald - Software Engineer and Engineering Manager";
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,6 +9,8 @@ interface Props {
   description?: string;
   image?: string;
   ogType?: string;
+  publishedTime?: Date;
+  modifiedTime?: Date;
 }
 
 const {
@@ -16,13 +18,22 @@ const {
   description = SITE_DESCRIPTION,
   image = SITE_OG_IMAGE,
   ogType,
+  publishedTime,
+  modifiedTime,
 } = Astro.props;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <MainHead {title} {description} {image} {ogType} />
+    <MainHead
+      {title}
+      {description}
+      {image}
+      {ogType}
+      {publishedTime}
+      {modifiedTime}
+    />
     <slot name="head" />
   </head>
   <body class="antialiased bg-body text-body font-body">

--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -69,6 +69,8 @@ const blogPostingSchema = {
   description={content.description}
   image={metaTagImage}
   ogType="article"
+  publishedTime={content.pubDate}
+  modifiedTime={content.lastmod}
 >
   <JsonLd slot="head" schema={blogPostingSchema} />
   <section class="relative py-20">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,11 +1,35 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import BlogPostPreviewListing from "../../components/BlogPostPreviewListing.astro";
+import JsonLd from "../../components/JsonLd.astro";
+import { getSortedBlogPosts } from "../../lib/blog";
+import { personSchema } from "../../lib/structured-data";
+import { SITE_DESCRIPTION } from "../../consts";
 
 const title =
   "Blog by Andy Grunwald - Software Engineer and Engineering Manager";
+
+const posts = await getSortedBlogPosts();
+
+// The listing was the only content page without structured data.
+const blogSchema = {
+  "@context": "https://schema.org",
+  "@type": "Blog",
+  name: title,
+  description: SITE_DESCRIPTION,
+  url: new URL(Astro.url.pathname, Astro.site).href,
+  author: personSchema,
+  blogPost: posts.map((post) => ({
+    "@type": "BlogPosting",
+    headline: post.data.title,
+    datePublished: post.data.pubDate.toISOString(),
+    dateModified: post.data.lastmod.toISOString(),
+    url: new URL(`/blog/${post.id}/`, Astro.site).href,
+  })),
+};
 ---
 
 <BaseLayout {title}>
+  <JsonLd slot="head" schema={blogSchema} />
   <BlogPostPreviewListing numberOfItems={0} />
 </BaseLayout>


### PR DESCRIPTION
## What

`MainHead.astro`, `BaseLayout.astro`, `blog-post.astro`, `blog/index.astro`, `consts.ts`.

| Tag | Note |
|---|---|
| `og:site_name`, `og:locale` | scrapers had nothing to attribute the page to |
| `og:image:alt` | card image was undescribed |
| `twitter:creator` | absent, though `twitter:site` was already there |
| `article:published_time` / `article:modified_time` | posts declared `og:type=article` without them, despite both dates being in frontmatter |
| `theme-color` | `#ffffff` — matches what `site.webmanifest` already declares |
| `<meta name="generator">` | recommended by the Astro docs |

Plus: `/blog/` was the only content page with **no structured data**. It now emits a `Blog` schema listing all 26 posts, reusing the shared `personSchema` rather than restating the author.

## Scoping

The article timestamps are optional props, so only posts emit them — the homepage, `/about/` and 404 stay `og:type=website` with no `article:*` tags. Verified in the build.

**The OG image is deliberately untouched** per your call: post cards still point at a content-hashed `/_astro/*.webp` that changes on every re-optimization. Real issue, separate PR whenever you want it.

## Verification

```
make format-check && make lint && npm run build
```

On a post:

```html
<meta name="generator" content="Astro v7.2.4">
<meta property="og:site_name" content="Andy Grunwald">
<meta property="og:locale" content="en_GB">
<meta property="article:published_time" content="2015-06-20T00:00:00.000Z">
<meta property="article:modified_time" content="2021-07-09T00:00:00.000Z">
<meta name="twitter:creator" content="@andygrunwald">
```

`/blog/` JSON-LD parses as valid JSON with `@type: Blog` and 26 `blogPost` entries. 404 emits no `article:*` tags.

## Unrelated thing I noticed

`public/site.webmanifest` has empty `"name"` and `"short_name"`. Not touching it here, but worth a one-line fix sometime.

P1 item from the Astro best-practice audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt