### PR TITLE
Publish the speaking and projects pages

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,6 +2,12 @@ import { defineCollection } from "astro:content";
 import { z } from "astro/zod";
 import { glob } from "astro/loaders";
 
+// The speaking entries use "" to mean "no link". Normalise that to undefined so
+// templates can test presence, while still validating anything non-empty.
+const optionalUrl = z
+  .union([z.url(), z.literal("")])
+  .transform((value) => value || undefined);
+
 const blogPostsCollection = defineCollection({
   loader: glob({ pattern: "**/*.mdx", base: "./src/content/blog" }),
   // `image()` resolves each path relative to the entry and fails the build on a
@@ -23,17 +29,18 @@ const blogPostsCollection = defineCollection({
 const publicSpeakingCollection = defineCollection({
   loader: glob({ pattern: "**/*.yml", base: "./src/content/speaking" }),
   schema: z.object({
-    title: z.string(),
+    // Trimmed because the title is what groups appearances into one talk.
+    title: z.string().trim(),
     date: z.date(),
     eventtype: z.string(),
     eventenddate: z.date(),
     eventtitle: z.string(),
-    eventlink: z.string(),
-    ratinglink: z.string(),
-    twittermoments: z.string(),
-    videolink: z.string(),
-    slides: z.string(),
-    picture: z.string(),
+    eventlink: optionalUrl,
+    ratinglink: optionalUrl,
+    twittermoments: optionalUrl,
+    videolink: optionalUrl,
+    slides: optionalUrl,
+    picture: z.string().optional(),
     city: z.string(),
     country: z.string(),
   }),
@@ -43,9 +50,9 @@ const projectCollection = defineCollection({
   loader: glob({ pattern: "**/*.mdx", base: "./src/content/project" }),
   schema: z.object({
     name: z.string(),
-    website: z.string(),
-    links: z.array(z.string()),
-    blogposts: z.array(z.string()),
+    website: z.url(),
+    links: z.array(z.url()),
+    blogposts: z.array(z.url()),
     startDate: z.date(),
     endDate: z.date(),
   }),

--- a/src/content/speaking/php-ug-muenster-2017-04.yml
+++ b/src/content/speaking/php-ug-muenster-2017-04.yml
@@ -1,5 +1,5 @@
 ---
-title: "Learn Redis the hard way ... in production "
+title: "Learn Redis the hard way ... in production"
 date: 2017-04-18
 eventtype: "meetup"
 eventenddate: 2017-04-18

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -11,3 +11,16 @@ export function formatDate(date: Date | string | null | undefined): string {
   if (isNaN(d.getTime())) return "";
   return d.toLocaleDateString("en-GB", options);
 }
+
+const shortOptions: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+};
+
+/** Compact form for dense listings, e.g. "5 Apr 2017". */
+export function formatShortDate(date: Date | string): string {
+  const d = new Date(date);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("en-GB", shortOptions);
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -6,6 +6,12 @@ export interface NavigationLink {
 
 export const navigationLinks: NavigationLink[] = [
   { label: "✍️ Blog", href: "/blog/", title: "Blog of Andy Grunwald" },
+  { label: "🎤 Speaking", href: "/speaking/", title: "Talks by Andy Grunwald" },
+  {
+    label: "🛠️ Projects",
+    href: "/projects/",
+    title: "Projects by Andy Grunwald",
+  },
   { label: "👨‍🔬 About", href: "/about/", title: "About Andy Grunwald" },
   {
     label: "🎙️ Engineering Kiosk Podcast",

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,0 +1,158 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { formatShortDate } from "../lib/date";
+import { getSortedBlogPosts } from "../lib/blog";
+
+const title = "Projects by Andy Grunwald - Communities and events";
+const description =
+  "Side projects by Andy Grunwald: the Web Engineering Meetup Düsseldorf and the localhost conference.";
+
+// The blogposts field holds absolute URLs to this site, so the real post
+// titles can be recovered instead of showing a bare count or a slug.
+const blogPosts = await getSortedBlogPosts();
+const postByPath = new Map(
+  blogPosts.map((post) => [`/blog/${post.id}/`, post]),
+);
+
+const entries = (await getCollection("project")).sort(
+  (a, b) => b.data.startDate.valueOf() - a.data.startDate.valueOf(),
+);
+
+// These projects differ mostly in how long they ran: eleven years against a
+// single day. Plotting them on one shared axis makes that the first thing you
+// see, rather than a fact buried in two date fields.
+const axisStart = new Date(
+  Math.min(...entries.map((e) => e.data.startDate.valueOf())),
+);
+const axisEnd = new Date(
+  Math.max(...entries.map((e) => e.data.endDate.valueOf())),
+);
+const axisSpan = axisEnd.valueOf() - axisStart.valueOf();
+
+const DAY = 1000 * 60 * 60 * 24;
+
+function span(startDate: Date, endDate: Date) {
+  const offset = (startDate.valueOf() - axisStart.valueOf()) / axisSpan;
+  const days = Math.round((endDate.valueOf() - startDate.valueOf()) / DAY);
+  const years = Math.round(days / 365);
+  return {
+    left: `${offset * 100}%`,
+    // Floor the width so a single-day project stays visible as a tick.
+    width: `max(0.5rem, ${((endDate.valueOf() - startDate.valueOf()) / axisSpan) * 100}%)`,
+    duration:
+      days < 2 ? "one day" : years < 1 ? `${days} days` : `${years} years`,
+  };
+}
+
+function relatedPosts(urls: string[]) {
+  return urls
+    .map((url) => postByPath.get(new URL(url).pathname))
+    .filter((post) => post !== undefined);
+}
+
+function labelFor(url: string) {
+  return new URL(url).hostname.replace(/^www\./, "");
+}
+---
+
+<BaseLayout {title} {description}>
+  <section class="py-20">
+    <div class="container px-4 mx-auto">
+      <div class="mb-16 max-w-3xl">
+        <h1 class="mt-8 mb-10 text-4xl font-semibold font-heading">
+          things i ran
+        </h1>
+        <p class="text-xl text-gray-500">
+          Communities and events I started or organised. They are laid out on a
+          shared timeline, because what separates them is mostly how long they
+          lasted.
+        </p>
+      </div>
+
+      <div class="max-w-4xl">
+        <div
+          class="flex justify-between mb-2 text-xs font-semibold uppercase tracking-widest text-gray-500 tabular-nums"
+        >
+          <span>{axisStart.getFullYear()}</span>
+          <span>{axisEnd.getFullYear()}</span>
+        </div>
+        <div class="h-px bg-gray-200 mb-12"></div>
+
+        {
+          entries.map((entry) => {
+            const bar = span(entry.data.startDate, entry.data.endDate);
+            return (
+              <article class="mb-16 pb-16 border-b border-gray-100 last:border-b-0">
+                <h2 class="mb-4 text-2xl font-semibold font-heading">
+                  <a
+                    href={entry.data.website}
+                    class="hover:underline hover:text-red-300"
+                  >
+                    {entry.data.name}
+                  </a>
+                </h2>
+
+                {/* Decorative: the same information is written out below it. */}
+                <div
+                  class="relative h-2 mb-3 rounded-full bg-gray-100"
+                  aria-hidden="true"
+                >
+                  <div
+                    class="absolute h-2 rounded-full bg-red-400"
+                    style={`left: ${bar.left}; width: ${bar.width};`}
+                  />
+                </div>
+
+                <p class="mb-6 text-sm text-gray-500 tabular-nums">
+                  <time datetime={entry.data.startDate.toISOString()}>
+                    {formatShortDate(entry.data.startDate)}
+                  </time>
+                  {" – "}
+                  <time datetime={entry.data.endDate.toISOString()}>
+                    {formatShortDate(entry.data.endDate)}
+                  </time>
+                  {" · "}
+                  {bar.duration}
+                </p>
+
+                <ul class="flex flex-wrap gap-x-4 gap-y-2">
+                  {[entry.data.website, ...entry.data.links].map((link) => (
+                    <li>
+                      <a
+                        href={link}
+                        class="text-sm font-medium text-red-400 hover:underline"
+                      >
+                        {labelFor(link)}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+
+                {relatedPosts(entry.data.blogposts).length > 0 && (
+                  <div class="mt-8">
+                    <h3 class="mb-3 text-xs font-semibold uppercase tracking-widest text-gray-500">
+                      Wrote about it
+                    </h3>
+                    <ul>
+                      {relatedPosts(entry.data.blogposts).map((post) => (
+                        <li class="mb-1">
+                          <a
+                            href={`/blog/${post.id}/`}
+                            class="text-sm text-gray-500 hover:underline hover:text-red-300"
+                          >
+                            {post.data.title}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </article>
+            );
+          })
+        }
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/speaking.astro
+++ b/src/pages/speaking.astro
@@ -1,0 +1,129 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../layouts/BaseLayout.astro";
+import { formatShortDate } from "../lib/date";
+
+const title = "Speaking by Andy Grunwald - Talks at conferences and meetups";
+const description =
+  "Conference and meetup talks by Andy Grunwald on containers in production, Redis, code quality and open source.";
+
+const appearances = (await getCollection("speaking")).sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+);
+
+// The same talk was given at several events, and that repetition is the point:
+// a talk is a thing that tours. Grouping by title says so; a flat list of nine
+// rows would hide it.
+const talks = [
+  ...new Map(appearances.map((a) => [a.data.title, []])).keys(),
+].map((talkTitle) => ({
+  title: talkTitle,
+  stops: appearances.filter((a) => a.data.title === talkTitle),
+}));
+
+const cities = new Set(appearances.map((a) => a.data.city));
+const years = appearances.map((a) => a.data.date.getFullYear());
+
+const summary = [
+  `${appearances.length} appearances`,
+  `${talks.length} talks`,
+  `${cities.size} cities`,
+  `${Math.min(...years)}–${Math.max(...years)}`,
+];
+
+// Only render a link row when the entry actually has something behind it.
+const linkFields = [
+  { key: "slides", label: "Slides" },
+  { key: "videolink", label: "Video" },
+  { key: "twittermoments", label: "Reactions" },
+  { key: "ratinglink", label: "Ratings" },
+] as const;
+---
+
+<BaseLayout {title} {description}>
+  <section class="py-20">
+    <div class="container px-4 mx-auto">
+      <div class="mb-16 max-w-3xl">
+        <h1 class="mt-8 mb-10 text-4xl font-semibold font-heading">
+          things i talked about
+        </h1>
+        <p class="text-xl text-gray-500">
+          Talks I gave at conferences and meetups, mostly about running
+          containers and databases in production. A talk is rarely given once,
+          so they are grouped by topic with every stage it reached underneath.
+        </p>
+      </div>
+
+      <ul
+        class="flex flex-wrap gap-x-8 gap-y-2 mb-20 text-xs font-semibold uppercase tracking-widest text-gray-500 tabular-nums"
+      >
+        {summary.map((item) => <li>{item}</li>)}
+      </ul>
+
+      <div class="max-w-4xl">
+        {
+          talks.map((talk) => (
+            <article class="mb-16">
+              <h2 class="mb-6 text-2xl font-semibold font-heading">
+                {talk.title}
+              </h2>
+
+              <ol class="border-l border-gray-200">
+                {talk.stops.map((stop) => (
+                  <li class="relative pl-6 pb-8 last:pb-0">
+                    {/* Marker sits on the rule so the stops read as one route. */}
+                    <span
+                      class="absolute left-0 top-2 -translate-x-1/2 w-2 h-2 rounded-full bg-red-400"
+                      aria-hidden="true"
+                    />
+
+                    <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                      <h3 class="text-lg font-semibold">
+                        {stop.data.eventlink ? (
+                          <a
+                            href={stop.data.eventlink}
+                            class="hover:underline hover:text-red-300"
+                          >
+                            {stop.data.eventtitle}
+                          </a>
+                        ) : (
+                          stop.data.eventtitle
+                        )}
+                      </h3>
+                      <span class="inline-block text-xs px-2 py-1 bg-blue-50 rounded uppercase text-blue-400 font-semibold">
+                        {stop.data.eventtype}
+                      </span>
+                    </div>
+
+                    <p class="mt-1 text-sm text-gray-500 tabular-nums">
+                      <time datetime={stop.data.date.toISOString()}>
+                        {formatShortDate(stop.data.date)}
+                      </time>
+                      {" · "}
+                      {stop.data.city}, {stop.data.country}
+                    </p>
+
+                    <ul class="flex flex-wrap gap-x-4 mt-2">
+                      {linkFields.map(({ key, label }) =>
+                        stop.data[key] ? (
+                          <li>
+                            <a
+                              href={stop.data[key]}
+                              class="text-sm font-medium text-red-400 hover:underline"
+                            >
+                              {label}
+                            </a>
+                          </li>
+                        ) : null,
+                      )}
+                    </ul>
+                  </li>
+                ))}
+              </ol>
+            </article>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## What

Two new pages — `/speaking/` and `/projects/` — plus the nav entries to reach them.

## Why

Both collections were defined and schema-validated on every build, and **no page consumed either**. Nine talks and two projects sat in the repo where nobody could read them.

## The design

I built each page around the fact its data actually carries, rather than rendering fields in the order they appear.

**Speaking — the fact is repetition.** Six talks were given at nine events: *Learn Redis the hard way* ran **three times across two countries**, *Challenges of containers* twice. A flat chronological list buries that. Appearances are grouped by talk, with each stage hanging off a shared rule so a talk reads as something that toured:

```
Learn Redis the hard way ... in production
 ●  DEVit                   CONFERENCE   20 May 2017 · Thessaloniki, Greece   Video
 ●  PHP-Usergroup Münster   MEETUP       18 Apr 2017 · Münster, Germany
 ●  Symfony Live            CONFERENCE    5 Apr 2017 · Cologne, Germany       Slides Video Reactions Ratings
```

A summary line states it outright: **9 appearances · 6 talks · 7 cities · 2013–2017**.

**Projects — the fact is duration.** An 11-year meetup next to a one-day conference *is* the story, so both are plotted on one shared 2012–2023 axis. Each bar sits on a faint track — that track earns its place: without it the single day floats as a stray dot, with it you can see *when* in the span it happened.

Write-ups resolve against the blog collection so real post titles show. The frontmatter holds absolute URLs; matching by path avoids either a bare count or a raw slug.

Everything uses the existing palette and Inter only. No new fonts, no new colours.

## Supporting changes

- **Speaking schema**: the `""` convention is normalised to `undefined` and non-empty values validated as URLs, so templates test presence instead of truthiness of `""`. Uses Zod 4's `z.url()`.
- **`title` is now trimmed** — one entry (`php-ug-muenster-2017-04.yml`) had a **trailing space**, which split *Learn Redis* into two groups and reported "7 talks". Fixed in the data too.
- **Nav**: both pages added, since content that can't be reached is barely published.

## Not done

The project `.mdx` bodies are still literally `TODO Description`, so **neither page renders them** — I wasn't going to publish that. Detail pages are worth building once there's prose.

---

## Rebased onto current `main`

This branch was 33 commits behind. Rebased with **no conflicts**, then fully re-verified rather than assuming the rebase was safe.

The rebase also means the new pages now inherit work that merged in the meantime — confirmed in the build:

- `og:image` points at `andy-grunwald-opengraph.jpg` (the purpose-built card from #606), not the deleted `.png`
- `og:site_name` and `<meta name="generator">` from the head-metadata PR are present

## Verification (re-run after the rebase)

```
make format-check && make lint && make check && make build   # 0 errors, 32 pages (was 30)
```

| check | result |
|---|---|
| speaking summary line | **9 appearances · 6 talks · 7 cities · 2013–2017** — the trailing-space grouping fix survived |
| projects durations | "one day" and "11 years", correct |
| related post titles | resolve from the blog collection |
| nav entries | `/speaking/` and `/projects/` present |
| sitemap | both URLs, 31 total (was 29) |

I viewed both pages in a browser when building them and iterated on the design twice.

P1 item from the Astro best-practice audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt