### PR TITLE
Encode webp images at quality 75

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -57,6 +57,22 @@ export default defineConfig({
     // cascade layer, so they would override the Tailwind object-fit
     // utilities this site uses on its images.
     layout: "constrained",
+    service: {
+      entrypoint: "astro/assets/services/sharp",
+      // Sharp defaults webp to quality 80. Dropping to 75 takes ~15% off the
+      // emitted images and is indistinguishable at 1:1 on this site's
+      // photography, which is the only kind of image it serves.
+      //
+      // `effort: 6` was measured and rejected: it saved a further 3.5% while
+      // taking the build from 4.6s to 30.3s, and CI re-encodes everything on
+      // every run because `make clean` drops the cache.
+      //
+      // Only the per-format keys are read here. A top-level `quality` would be
+      // silently ignored.
+      config: {
+        webp: { quality: 75 },
+      },
+    },
   },
   vite: {
     plugins: [tailwindcss()],


### PR DESCRIPTION
## What

`astro.config.mjs` — configures the default Sharp service:

```js
service: {
  entrypoint: "astro/assets/services/sharp",
  config: { webp: { quality: 75 } },
}
```

## Measured, not guessed

Three cold builds (`rm -rf node_modules/.astro dist .astro` each time):

| config | build time | webp emitted | largest variant | `dist/` |
|---|---|---|---|---|
| **baseline** (q80, effort 4) | 4.65s | 19,688 KB | 588 KB | 26 MB |
| **q75, effort 4** ← this PR | **4.56s** | **16,676 KB** (−15.3%) | **488 KB** (−17%) | **23 MB** |
| q75, effort 6 | 30.29s | 15,996 KB (−18.8%) | 468 KB | 22 MB |

## Why not `effort: 6`

The audit recommended it. **Measured, it's a bad trade:** a further 680 KB (−3.5%) for **+25.7s of build time — 6.5× slower**. CI re-encodes every image on every run because `make clean` drops the cache, so that cost lands on every push, PR and nightly build. Rejected.

## Quality check

Compared at 1:1 on the hardest case in the library — dark fabric texture behind fine gold embroidery (`final-game-show-buzzer-event-setup`, the worst asset on the site). Baseline and q75 are indistinguishable; texture detail and the small lettering both survive.

## Correction to the audit

The report suggested `image.service.config = { quality: 75 }`. **That does nothing.** Reading `node_modules/astro/dist/assets/services/sharp.js:23-56`, only `serviceConfig.jpeg` / `.png` / `.webp` / `.avif` are consumed — a top-level `quality` is never read. The working shape is `config: { webp: { … } }`, which is what this PR uses. The config comment records that so the next person doesn't repeat it.

## Not doing

Downscaling the source images. Two are 4032×3024 straight off a phone camera, which is the deeper cause of the large variants — but that edits your originals and permanently limits what the site can serve. Flagging it, not acting on it.

## Verification

```
make format-check && make lint && make check && make build
```

Client JS unchanged (1 file).

P2 item from the Astro best-practice audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt