### PR TITLE
Give the web manifest a name

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Andy Grunwald",
+    "short_name": "andygrunwald",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
## What

`public/site.webmanifest`:

```diff
-    "name": "",
-    "short_name": "",
+    "name": "Andy Grunwald",
+    "short_name": "andygrunwald",
```

## Why

Both fields shipped empty, so installing the site to a phone home screen or desktop produced an icon labelled with **nothing**.

`name` matches `SITE_NAME` in `src/consts.ts:4`. `short_name` uses the lowercase wordmark the header and footer already show — that's the form that fits under an icon.

## Verification

Manifest parses as valid JSON; `dist/site.webmanifest` matches the source byte for byte after build.

Spotted while auditing `public/` for orphaned assets — not on the original list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt