### PR TITLE
Render the listing heading once, with a dynamic tag

### DIFF
--- a/src/components/BlogPostPreviewListing.astro
+++ b/src/components/BlogPostPreviewListing.astro
@@ -3,7 +3,7 @@ import BlogPostPreview from "../components/BlogPostPreview.astro";
 import { getSortedBlogPosts } from "../lib/blog";
 
 export interface Props {
-  // Number of items to show in the listing
+  // How many posts to show. 0 lists every post.
   numberOfItems: number;
 }
 
@@ -11,34 +11,22 @@ const { numberOfItems } = Astro.props;
 
 const allPosts = await getSortedBlogPosts();
 
-// Default wise list all items, only limit it if requested
-let postsToShow = allPosts;
-let showAllButton = false;
-let mainPage = true;
-if (numberOfItems > 0) {
-  postsToShow = allPosts.slice(0, numberOfItems);
-  showAllButton = true;
-  mainPage = false;
-}
+// 0 means the full archive at /blog/; any positive number is an excerpt
+// embedded in another page, which then links onward to the archive.
+const isFullListing = numberOfItems <= 0;
+const postsToShow = isFullListing ? allPosts : allPosts.slice(0, numberOfItems);
+
+// The archive owns the page, so its heading is the h1. An excerpt sits under
+// the host page's own h1 and has to step down a level.
+const Heading = isFullListing ? "h1" : "h2";
 ---
 
 <section class="py-20">
   <div class="container px-4 mx-auto">
     <div class="mb-20">
-      {
-        mainPage && (
-          <h1 class="mt-8 mb-10 text-4xl font-semibold font-heading" id="blog">
-            things i wrote about
-          </h1>
-        )
-      }
-      {
-        !mainPage && (
-          <h2 class="mt-8 mb-10 text-4xl font-semibold font-heading" id="blog">
-            things i wrote about
-          </h2>
-        )
-      }
+      <Heading class="mt-8 mb-10 text-4xl font-semibold font-heading" id="blog">
+        things i wrote about
+      </Heading>
       <p class="text-xl text-gray-500">
         Writing is an invaluable skill that needs to be trained like every other
         muscle. Writing forces you to think more about a topic, how to express
@@ -50,7 +38,7 @@ if (numberOfItems > 0) {
     {postsToShow.map((post) => <BlogPostPreview post={post} />)}
 
     {
-      showAllButton && (
+      !isFullListing && (
         <div class="text-center">
           <a
             class="px-8 py-4 text-sm text-white font-semibold bg-red-400 hover:bg-red-300 rounded transition duration-200"


### PR DESCRIPTION
## What

`BlogPostPreviewListing.astro` — collapses the duplicated heading, renames `mainPage`, drops two now-redundant bindings.

## Why

The heading existed **twice**, character-for-character identical apart from the tag name:

```astro
{ mainPage && (<h1 class="mt-8 mb-10 …" id="blog">things i wrote about</h1>) }
{ !mainPage && (<h2 class="mt-8 mb-10 …" id="blog">things i wrote about</h2>) }
```

Astro renders a capitalised variable as a tag, so `<Heading>` says the same thing once and the two copies can't drift apart.

## The naming bug

`mainPage` meant the **opposite** of what it said:

| Page | `numberOfItems` | `mainPage` |
|---|---|---|
| `/blog/` (the archive) | `0` | **`true`** |
| `/` (the home page) | `3` | **`false`** |

`isFullListing` is what the value actually describes. With the name fixed, the three `let` bindings become derived `const`s, and `showAllButton` disappears entirely — it was only ever the negation of the same condition.

## Verification

```
make format-check && make lint && make check && make build
```

Build output **byte-identical**. Behaviour spot-checked in `dist/`:

| | heading | "View all" button |
|---|---|---|
| `/` | `<h2>` | 1 |
| `/blog/` | `<h1>` | 0 |

> **Stacked PR** — based on #609. Review just the top commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt