### PR TITLE
Stop nesting a div inside the home page h1

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,9 +19,11 @@ const homeSchema = {
         <span class="text-blue-400 font-semibold text-3xl">
           Andy Grunwald
         </span>
-        <div class="mt-8 mb-8 lg:mb-12 text-4xl lg:text-6xl font-semibold">
+        <span
+          class="block mt-8 mb-8 lg:mb-12 text-4xl lg:text-6xl font-semibold"
+        >
           Engineering Manager and Software Engineer.
-        </div>
+        </span>
       </h1>
       <p class="max-w-3xl mx-auto mb-8 lg:mb-12 text-xl text-gray-500">
         I manage engineers at <a


### PR DESCRIPTION
## What

`src/pages/index.astro` — the `<div>` inside `<h1>` becomes `<span class="block …">`.

## Why

`<h1>` takes **phrasing content**; a `<div>` there has never been valid. Browsers respond by closing the `<h1>` early and leaving the rest of the headline outside the heading.

**Astro 7 made this consequential.** Its Rust compiler no longer auto-repairs invalid nesting the way the Go compiler quietly did — what ships is now exactly what was written.

Tailwind's `block` utility gives the `<span>` the identical computed style (`display: block`) that the `<div>` had by default. The rest of the class list is untouched.

## Verification

```
make format-check && make lint && make check && make build
```

Token-level diff of every emitted `.html`/`.xml` against `main` shows **exactly four lines** — the two tag names, nothing else:

```
-<div class="mt-8 mb-8 lg:mb-12 text-4xl lg:text-6xl font-semibold">
+<span class="block mt-8 mb-8 lg:mb-12 text-4xl lg:text-6xl font-semibold">
-</div>
+</span>
```

P2 item from the Astro best-practice audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt