### PR TITLE
Lazy-load the YouTube embeds

### DIFF
--- a/src/components/YouTube.astro
+++ b/src/components/YouTube.astro
@@ -24,6 +24,7 @@ if (!/^[a-zA-Z0-9_-]{11}$/.test(id)) {
       frameborder="0"
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
       allowfullscreen
+      loading="lazy"
       class="inline"></iframe>
   </div>
   <div class="video-description">


### PR DESCRIPTION
## What

`src/components/YouTube.astro` — adds `loading="lazy"` to the iframe.

## Why

The embeds always sit mid-article, never above the fold. Without a `loading` attribute every one opened a connection to `youtube-nocookie.com` and pulled the player **as soon as the page parsed**, whether or not the reader ever scrolled that far.

**6 embeds across the blog** are affected.

## Verification

```
make format-check && make lint && make check && make build
```

Token-level diff against `main` shows only the 6 iframe tags, each differing by the added attribute. Confirmed in the built HTML:

```html
<iframe … src="https://www.youtube-nocookie.com/embed/…" … loading="lazy" class="inline">
```

## Noted, not changed

The same tag carries `frameborder="0"`, which `astro check` already flags as deprecated and which the inline `border:0` makes redundant. Out of scope for this PR — say the word if you want it.

P2 item from the Astro best-practice audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt