### PR TITLE
Keep the footer TODO out of the shipped HTML

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -9,7 +9,7 @@ const year = new Date().getFullYear();
     <div class="pb-6 lg:pb-10 border-b border-gray-100">
       <div class="flex flex-wrap items-start justify-between">
         <div class="w-full md:w-1/3">
-          <!-- TODO The logo is not item-center (in line with the nav) -->
+          {/* TODO The logo is not item-center (in line with the nav) */}
           <a class="inline-block text-gray-900 text-lg font-semibold" href="/">
             <span class="text-lg font-semibold">
               <span class="text-red-400">&raquo;</span> andygrunwald


### PR DESCRIPTION
## What

`src/components/Footer.astro:12`:

```diff
-<!-- TODO The logo is not item-center (in line with the nav) -->
+{/* TODO The logo is not item-center (in line with the nav) */}
```

## Why

Astro does not strip HTML comments, so a note left for the author was being delivered to every visitor — it appeared in **all 30 pages** of the build.

A JSX-style comment isn't emitted. The note stays next to the markup it describes, where it's useful, and stops being part of the payload.

The TODO is still accurate, so it's **preserved rather than deleted** — this is about where it lives, not whether it's worth keeping.

## Verification

```
grep -rl 'TODO' dist/ --include='*.html' | wc -l     # 30 → 0
make format-check && make lint && make check && make build
```

Token-level diff against `main` shows exactly one class of change across 30 files: the comment's absence.

P2 item from the Astro best-practice audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt