### PR TITLE
Collapse the one-utility-per-line @apply in blogpost.css

### DIFF
--- a/src/styles/blogpost.css
+++ b/src/styles/blogpost.css
@@ -6,25 +6,15 @@
 */
 article {
   h2 {
-    @apply mt-16;
-    @apply mb-8;
-    @apply text-3xl;
-    @apply font-semibold;
-    @apply font-heading;
+    @apply mt-16 mb-8 text-3xl font-semibold font-heading;
   }
 
   h3 {
-    @apply mb-6;
-    @apply text-2xl;
-    @apply font-semibold;
-    @apply font-heading;
+    @apply mb-6 text-2xl font-semibold font-heading;
   }
 
   h4 {
-    @apply mb-4;
-    @apply text-xl;
-    @apply font-semibold;
-    @apply font-heading;
+    @apply mb-4 text-xl font-semibold font-heading;
   }
 
   hr {
@@ -32,76 +22,53 @@ article {
   }
 
   pre.astro-code {
-    @apply px-6;
-    @apply py-6;
-    @apply mb-6;
+    @apply px-6 py-6 mb-6;
   }
 
   .video-description {
     @apply text-center;
 
     p {
-      @apply text-base;
-      @apply text-gray-500;
-      @apply pt-3;
+      @apply text-base text-gray-500 pt-3;
     }
   }
 
   p {
-    @apply mb-6;
-    @apply text-xl;
-    @apply text-gray-500;
+    @apply mb-6 text-xl text-gray-500;
 
     a {
-      @apply hover:underline;
-      @apply text-red-300;
+      @apply hover:underline text-red-300;
     }
 
     img {
-      @apply w-full;
-      @apply h-full;
-      @apply object-cover;
-      @apply rounded-lg;
+      @apply w-full h-full object-cover rounded-lg;
     }
 
     code {
-      @apply text-red-300;
-      @apply bg-gray-50;
-      @apply border-gray-200;
-      @apply p-1;
+      @apply text-red-300 bg-gray-50 border-gray-200 p-1;
     }
   }
 
   figcaption {
-    @apply text-base;
-    @apply text-gray-500;
-    @apply text-center;
-    @apply pt-3;
+    @apply text-base text-gray-500 text-center pt-3;
   }
 
   .quote {
     div {
       p {
-        @apply text-2xl;
-        @apply leading-loose;
+        @apply text-2xl leading-loose;
       }
     }
   }
 
   ul {
-    @apply list-disc;
-    @apply px-5;
-    @apply mb-4;
-    @apply md:px-5;
-    @apply text-xl;
-    @apply text-gray-500;
+    @apply list-disc px-5 mb-4 md:px-5 text-xl text-gray-500;
 
     li {
       @apply mb-2;
 
       a {
-        @apply hover:underline;
-        @apply text-red-300;
+        @apply hover:underline text-red-300;
       }
 
       ul {
@@ -115,35 +82,22 @@ article {
   }
 
   ol {
-    @apply list-decimal;
-    @apply px-5;
-    @apply mb-4;
-    @apply md:px-5;
-    @apply text-xl;
-    @apply text-gray-500;
+    @apply list-decimal px-5 mb-4 md:px-5 text-xl text-gray-500;
 
     li {
       @apply mb-2;
 
       a {
-        @apply hover:underline;
-        @apply text-red-300;
+        @apply hover:underline text-red-300;
       }
     }
   }
 
   blockquote {
-    @apply py-10;
-    @apply px-8;
-    @apply mb-6;
-    @apply bg-gray-50;
-    @apply rounded-lg;
-    @apply text-xl;
-    @apply text-gray-500;
+    @apply py-10 px-8 mb-6 bg-gray-50 rounded-lg text-xl text-gray-500;
 
     p {
-      @apply text-xl;
-      @apply leading-loose;
+      @apply text-xl leading-loose;
     }
   }
 }


### PR DESCRIPTION
## What

`src/styles/blogpost.css` — **149 lines → 103**, **69 `@apply` statements → 23**.

```diff
   h2 {
-    @apply mt-16;
-    @apply mb-8;
-    @apply text-3xl;
-    @apply font-semibold;
-    @apply font-heading;
+    @apply mt-16 mb-8 text-3xl font-semibold font-heading;
   }
```

Every one of the 69 statements carried exactly one utility, so a five-utility rule took five lines to say what `@apply` takes a list for.

## The emitted CSS is *not* byte-identical — and that's expected

I planned to require byte-identical output. **That bar was wrong**, and I'd rather say so than quietly move the goalposts. Two things legitimately change:

1. Utilities sharing one `@apply` are emitted in Tailwind's **canonical property order**, not source order.
2. For a rule that also has a responsive variant (`ul`/`ol` use `px-5` *and* `md:px-5`), the base declarations now group together ahead of the media query instead of straddling it.

## What I verified instead

Semantic equivalence — the thing that actually matters. Parsed both built stylesheets into `(media context, selector) → {property: final value}`, honouring last-wins ordering:

```
contexts: 31 -> 31
context sets equal: True
contexts with different COMPUTED declarations: 0
```

Also checked that **no rule mixes a shorthand with one of its own longhands** (`padding`/`padding-top`, `margin`/`margin-*`, etc.), which is the one case where reordering could change the result: **0 occurrences**.

The file is 22 bytes smaller (5,170 → 5,148).

## Verification

```
make format-check && make lint && make check && make build
```

The only change in the emitted HTML is the stylesheet's content hash in the `<link>`, across 26 blog pages.

P2 item from the Astro best-practice audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt