### PR TITLE
Delete the write-only class name helpers

### DIFF
--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -24,14 +24,6 @@ const title = `${content.title} - Andy Grunwald`;
 const firstImage = content.images.at(0) ?? null;
 const headerImage = content.showHeaderImage ? firstImage : null;
 
-// Pre-existing, currently unused layout helpers (kept, marked intentional).
-let _imageWidthClass = "";
-let _imagePaddingLeftClass = "";
-if (headerImage) {
-  _imageWidthClass = "lg:w-2/5";
-  _imagePaddingLeftClass = "lg:pl-10";
-}
-
 // Open graph / Twitter card image: prefer the optimized asset's URL, then the
 // raw path, then the default site card. MainHead absolutizes it via new URL().
 const metaTagImage = firstImage ? firstImage.src : SITE_OG_IMAGE;


### PR DESCRIPTION
## What

`src/layouts/blog-post.astro` — removes `_imageWidthClass` and `_imagePaddingLeftClass`.

## Why

Both were assigned and **never read**. A repo-wide search finds only the four assignment lines. The `_` prefix existed solely to satisfy the custom `varsIgnorePattern: "^_"` ESLint rule — the tooling had been taught to ignore the problem rather than the problem being fixed.

## They weren't free

This is the part I didn't expect. Tailwind scans source files for class-name strings, so those two dead literals caused real CSS to be generated into the stylesheet **every page loads**:

```diff
-.lg\:pl-10{padding-left:calc(var(--spacing) * 10)}
-.lg\:w-2\/5{width:40%}
```

Confirmed no markup has ever carried either class (**0 files** in the built HTML, before or after). So the dead code was dragging dead CSS along with it — **−72 bytes on every page**.

## Verification

```
make format-check && make lint && make check && make build
```

Rule-level diff of the base stylesheet shows **exactly those two rules removed and nothing added**. `headerImage`, computed just above, is still used to render the header image (`:82`, `:85`).

## Note on scope

My standing instruction is to flag pre-existing dead code rather than delete it, which is why the earlier PRs left this alone and only annotated it. You listed it explicitly this time, so I'm treating that as authorisation for this specific case.

P2 item from the Astro best-practice audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf2gdTQVohgojQekXxwxAt